### PR TITLE
bug: fixes for py3 and latest sisl development

### DIFF
--- a/Hubbard/__init__.py
+++ b/Hubbard/__init__.py
@@ -8,3 +8,6 @@ Package for mean-field Hubbard approximation
 .. module:: Hubbard
 
 """
+
+from .hamiltonian import *
+from . import plot

--- a/Hubbard/hamiltonian.py
+++ b/Hubbard/hamiltonian.py
@@ -288,7 +288,7 @@ class HubbardHamiltonian(sisl.Hamiltonian):
         s += 'eN=%.2f '%self.eN
         s += 'Nup=%.2f '%self.Nup
         s += 'Ndn=%.2f '%self.Ndn
-        myhash = int(hashlib.md5(s).hexdigest()[:7], 16)
+        myhash = int(hashlib.md5(s.encode('utf-8')).hexdigest()[:7], 16)
         return myhash, s
 
     def save(self, ncgroup=None):

--- a/Hubbard/plot/__init__.py
+++ b/Hubbard/plot/__init__.py
@@ -9,9 +9,9 @@ Functionality for Plotting
 
 """
 
-from plot import *
-from charge import *
-from wavefunction import *
-from spectrum import *
-from bandstructure import *
-from bonds import *
+from .plot import *
+from .charge import *
+from .wavefunction import *
+from .spectrum import *
+from .bandstructure import *
+from .bonds import *

--- a/examples/molecules/2B-7AGNR/compute_5x3.py
+++ b/examples/molecules/2B-7AGNR/compute_5x3.py
@@ -7,7 +7,7 @@ import sisl
 pol = False
 
 # Build sisl Geometry object
-fn = sisl.get_sile('7AGNR2B_5x3.XV').read_geom()
+fn = sisl.get_sile('7AGNR2B_5x3.XV').read_geometry()
 fn.sc.set_nsc([1,1,1])
 fn = fn.move(-fn.center(what='xyz'))
 

--- a/examples/molecules/2B-7AGNR/compute_5x5.py
+++ b/examples/molecules/2B-7AGNR/compute_5x5.py
@@ -7,7 +7,7 @@ import sisl
 pol = False
 
 # Build sisl Geometry object
-fn = sisl.get_sile('7AGNR2B_5x5.XV').read_geom()
+fn = sisl.get_sile('7AGNR2B_5x5.XV').read_geometry()
 fn.sc.set_nsc([1,1,1])
 fn = fn.move(-fn.center(what='xyz'))
 

--- a/examples/molecules/anthracenes/compute.py
+++ b/examples/molecules/anthracenes/compute.py
@@ -5,7 +5,7 @@ import sisl
 
 # Build sisl Geometry object
 mol_file = '2-anthracene.XV'
-fn = sisl.get_sile(mol_file).read_geom()
+fn = sisl.get_sile(mol_file).read_geometry()
 fn.sc.set_nsc([1,1,1])
 fn = fn.move(-fn.center(what='xyz'))
 

--- a/examples/molecules/clar-goblet/compute_FM-AFM.py
+++ b/examples/molecules/clar-goblet/compute_FM-AFM.py
@@ -5,7 +5,7 @@ import numpy as np
 import sisl
 
 # Build sisl Geometry object
-fn = sisl.get_sile('clar-goblet.xyz').read_geom()
+fn = sisl.get_sile('clar-goblet.xyz').read_geometry()
 fn.sc.set_nsc([1,1,1])
 fn = fn.move(-fn.center(what='xyz'))
 

--- a/examples/molecules/kondo-paper/fig_S11-S13.py
+++ b/examples/molecules/kondo-paper/fig_S11-S13.py
@@ -5,7 +5,7 @@ import numpy as np
 import sisl
 
 # Build sisl Geometry object
-fn = sisl.get_sile('junction-2-2.XV').read_geom()
+fn = sisl.get_sile('junction-2-2.XV').read_geometry()
 fn.sc.set_nsc([1,1,1])
 fn = fn.move(-fn.center(what='xyz')).rotate(220, [0,0,1])
 

--- a/examples/molecules/kondo-paper/fig_S14.py
+++ b/examples/molecules/kondo-paper/fig_S14.py
@@ -4,7 +4,7 @@ import numpy as np
 import sisl
 
 # Build sisl Geometry object
-fn = sisl.get_sile('junction-2-2.XV').read_geom()
+fn = sisl.get_sile('junction-2-2.XV').read_geometry()
 fn.sc.set_nsc([1,1,1])
 
 # 3NN tight-binding model

--- a/examples/molecules/triangulene/compute_FM-AFM.py
+++ b/examples/molecules/triangulene/compute_FM-AFM.py
@@ -5,7 +5,7 @@ import numpy as np
 import sisl
 
 # Build sisl Geometry object
-fn = sisl.get_sile('triangulene.xyz').read_geom()
+fn = sisl.get_sile('triangulene.xyz').read_geometry()
 fn = fn.move(-fn.center(what='xyz'))
 fn.sc.set_nsc([1,1,1])
 

--- a/examples/periodic/7AGNR/compute.py
+++ b/examples/periodic/7AGNR/compute.py
@@ -5,7 +5,7 @@ import sys
 import sisl
 
 fn = sys.argv[1]
-geom = sisl.get_sile(fn).read_geom()
+geom = sisl.get_sile(fn).read_geometry()
 geom = geom.move(-geom.center(what='xyz'))
 geom.set_nsc([3,1,1])
 

--- a/examples/periodic/chiralGNRs/compute.py
+++ b/examples/periodic/chiralGNRs/compute.py
@@ -12,7 +12,7 @@ def compute(fn):
     head, tail = os.path.split(fn)
     
     # Build sisl Geometry object
-    geom = sisl.get_sile(fn).read_geom()
+    geom = sisl.get_sile(fn).read_geometry()
     geom = geom.move(-geom.center(what='xyz'))
     geom.set_nsc([3,1,1])
 

--- a/examples/periodic/ssh/compute.py
+++ b/examples/periodic/ssh/compute.py
@@ -7,7 +7,7 @@ import matplotlib.pyplot as plt
 fn = sys.argv[1]
 
 # Read geometry and set up SSH Hamiltonian
-geom = sisl.get_sile(fn).read_geom()
+geom = sisl.get_sile(fn).read_geometry()
 geom.set_nsc([3, 1, 1])
 H = sisl.Hamiltonian(geom)
 for ia in geom:

--- a/tests/test-hubbard-plots.py
+++ b/tests/test-hubbard-plots.py
@@ -7,7 +7,7 @@ import sisl
 # using a reference molecule (already converged)
 
 # Build sisl Geometry object
-fn = sisl.get_sile('mol-ref/mol-ref.XV').read_geom()
+fn = sisl.get_sile('mol-ref/mol-ref.XV').read_geometry()
 fn.sc.set_nsc([1,1,1])
 fn = fn.move(-fn.center(what='xyz')).rotate(220, [0,0,1])
 

--- a/tests/test-hubbard-quantitative.py
+++ b/tests/test-hubbard-quantitative.py
@@ -6,7 +6,7 @@ import sisl
 # using a reference molecule (already converged)
 
 # Build sisl Geometry object
-fn = sisl.get_sile('mol-ref/mol-ref.XV').read_geom()
+fn = sisl.get_sile('mol-ref/mol-ref.XV').read_geometry()
 fn.sc.set_nsc([1,1,1])
 
 H = hh.HubbardHamiltonian(fn, fn_title='mol-ref/mol-ref', U=3.5)

--- a/tests/test-hubbard-quick.py
+++ b/tests/test-hubbard-quick.py
@@ -4,7 +4,7 @@ import Hubbard.hamiltonian as hh
 import sisl
 
 # Build sisl Geometry object
-fn = sisl.get_sile('mol-ref/mol-ref.XV').read_geom()
+fn = sisl.get_sile('mol-ref/mol-ref.XV').read_geometry()
 fn.sc.set_nsc([1,1,1])
 
 # Run one iteration


### PR DESCRIPTION
- read_geom is deprecated in sisl, use read_geometry

- md5 hash in py3 requires utf-8 encoding (note my fix is untested on py2,
  but I guess it should work)

- Fixed imports

Signed-off-by: Nick Papior <nickpapior@gmail.com>