### PR TITLE
Mfh negf nicpa

### DIFF
--- a/tests/test-hubbard-open.py
+++ b/tests/test-hubbard-open.py
@@ -8,7 +8,7 @@ import Hubbard.hamiltonian as hh
 import Hubbard.sp2 as sp2
 
 # Set U for the whole calculation
-U = 3.0
+U = 3.
 
 # Build zigzag GNR
 ZGNR = geometry.zgnr(2)
@@ -17,7 +17,7 @@ ZGNR = geometry.zgnr(2)
 H_elec = sp2(ZGNR, t1=2.7, t2=0.2, t3=0.18)
 
 # Hubbard Hamiltonian of elecs
-MFH_elec = hh.HubbardHamiltonian(H_elec, U=U, nkpt=[101, 1, 1])
+MFH_elec = hh.HubbardHamiltonian(H_elec, U=U, nkpt=[102, 1, 1])
 
 # Converge Electrode Hamiltonians
 dn = MFH_elec.converge(method=2)
@@ -34,4 +34,10 @@ MFH_HC = hh.HubbardHamiltonian(HC.H, DM=MFH_elec.DM.tile(3,axis=0), U=U, elecs=M
 
 # Converge using iterative method 3
 dn = MFH_HC.converge(method=3, steps=1)
+print(MFH_HC.nup.sum(), MFH_HC.ndn.sum())
+
+# Reference test for total energy
+HC = H_elec.tile(3,axis=0)
+MFH_HC = hh.HubbardHamiltonian(HC.H, DM=MFH_elec.DM.tile(3,axis=0), U=U, nkpt=[int(102/3), 1, 1])
+dn = MFH_HC.converge(method=2, steps=1)
 print(MFH_HC.nup.sum(), MFH_HC.ndn.sum())


### PR DESCRIPTION
A first draft for converging the fermi-level using the open system.

This is largely what is done in transiesta.

The basic method is:

1. Calculate charge
2. Calculate `dq` which is the deviation charge
3. Calculate the charge sitting at the current Fermi-level to estimate how much the Fermi-level should be shifted
4. Estimate the shift in the Fermi-level. Ideally this should be interpolated in some way. However, there are some problems with this since the populations keeps changing in the SCF.

The exact procedure in transiesta is:
1. Converge Hamiltonian
2. Calculate the deviation charge
3. Calculate the new fermi-level
4. Go to 1

This is different than what I just implemented since my implementation does the fermi-shift all the time which can mess up things.
I think you need to do something similar.
