### PR TITLE
enh: updated hamiltonian to obtain also NEQ Density matrix

### DIFF
--- a/Hubbard/hamiltonian.py
+++ b/Hubbard/hamiltonian.py
@@ -110,17 +110,17 @@ class HubbardHamiltonian(object):
                 w_neq = dE * ( dist(self.CC_neq.real - mu[0]) - dist(self.CC_neq.real - mu[1]) )
                 # Store weights for correction to RIGHT [0] and LEFT [1]
                 self.w_neq = np.array([w_neq, -w_neq]) / np.pi
-
-                # Initialize the neq-self-energies matrix
-                # electrode, spin, energy
-                self._cc_neq_SE = [[[None] * len(self.CC_neq)] * 2] * 2
+            else:
+                self.CC_neq = []
 
             self.elec_indx = [np.array(idx).reshape(-1, 1) for idx in elec_indx]
 
             # electrode, spin
-            self._ef_SE = [[None] * 2] * 2
+            self._ef_SE = []
             # electrode, spin, EQ-contour, energy
-            self._cc_eq_SE = [[[[None] * self.CC_eq.shape[1]] * self.CC_eq.shape[0]] * 2] * 2
+            self._cc_eq_SE = []
+            # electrode, spin, energy
+            self._cc_neq_SE = []
 
             for i, elec in enumerate(elecs):
                 Ef_elec = elec.H.fermi_level(elec.mp, q=[elec.Nup, elec.Ndn], distribution=dist)
@@ -131,18 +131,24 @@ class HubbardHamiltonian(object):
                 # potential back.
                 elec.H.shift(-Ef_elec - mu[i])
                 se = sisl.RecursiveSI(elec.H, elec_dir[i])
+                _cc_eq_SE = np.array([[[None] * self.CC_eq.shape[1]] * self.CC_eq.shape[0]] * 2 )
+                _ef_SE = np.array([None] * 2)
+                _cc_neq_SE = np.array([[None] * len(self.CC_neq)] * 2)
                 for spin in [0,1]:
                     # Map self-energy at the Fermi-level of each electrode into the device region
-                    self._ef_SE[i][spin] = se.self_energy(2 * mu[i] + 1j * self.eta, spin=spin)
+                    _ef_SE[spin] = se.self_energy(2 * mu[i] + 1j * self.eta, spin=spin)
 
                     for cc_eq_i, CC_eq in enumerate(self.CC_eq):
                         for ic, cc in enumerate(CC_eq):
                             # Do it also for each point in the CC, for all EQ CC
-                            self._cc_eq_SE[i][spin][cc_eq_i][ic] = se.self_energy(cc, spin=spin)
+                            _cc_eq_SE[spin][cc_eq_i][ic] = se.self_energy(cc, spin=spin)
                     if self.NEQ:
                         for ic, cc in enumerate(self.CC_neq):
                             # And for each point in the Neq CC
-                            self._cc_neq_SE[i][spin][ic] = se.self_energy(cc, spin=spin)
+                            _cc_neq_SE[spin][ic] = se.self_energy(cc, spin=spin)
+                self._ef_SE.append(_ef_SE)
+                self._cc_eq_SE.append(_cc_eq_SE)
+                self._cc_neq_SE.append(_cc_neq_SE)
 
     def eigh(self, k=[0, 0, 0], eigvals_only=True, spin=0):
         return self.H.eigh(k=k, eigvals_only=eigvals_only, spin=spin)

--- a/examples/open/benchmarks/ZGNR-constriction/setup.py
+++ b/examples/open/benchmarks/ZGNR-constriction/setup.py
@@ -74,7 +74,7 @@ p = plot.SpinPolarization(MFH_HC, colorbar=True)
 p.savefig('spin_HC.pdf')
 
 # Shift with Fermi-level of the device and write Hamiltonian into netcdf file
-MFH_HC.H.shift(-MFH_HC.Ef)
+MFH_HC.H.shift(MFH_HC.Ef)
 MFH_HC.H.write('MFH_HC.nc')
 
 # RUN TBtrans and plot transmissions

--- a/tests/test-transmission-open.py
+++ b/tests/test-transmission-open.py
@@ -35,7 +35,7 @@ HC = H_elec.tile(3,axis=0)
 HC.set_nsc([1,1,1])
 
 # Map electrodes in the device region
-elec_indx = [range(len(H_elec)), range(len(HC.H)-len(H_elec), len(HC.H))]
+elec_indx = [range(len(H_elec)), range(-len(H_elec), 0)]
 
 # MFH object
 MFH_HC = hh.HubbardHamiltonian(HC.H, DM=MFH_elec.DM.tile(3,axis=0), U=U, elecs=[MFH_elec, MFH_elec], elec_indx=elec_indx, elec_dir=['-A', '+A'], kT=kT)
@@ -45,7 +45,7 @@ dn = MFH_HC.converge(method=3, steps=1, tol=1e-5)
 print('Nup, Ndn: ', MFH_HC.nup.sum(), MFH_HC.ndn.sum())
 
 # Shift device with its Fermi level and write nc file
-MFH_HC.H.shift(-MFH_HC.Ef)
+MFH_HC.H.shift(MFH_HC.Ef)
 MFH_HC.H.write('MFH_HC.nc')
 
 print(abs(MFH_elec.tile(3,axis=0).nup - MFH_HC.nup).sum())


### PR DESCRIPTION
This is the first attempt to obtain the NEQ Density matrix from the Complex Contours obtained from Transiesta. The code now looks a bit messy, I think that maybe we could use a common iterative method where only the calculation of the occupations changes for the different calculations, instead of having several iterative methods. As a starting point we probably should store what is related to the Green's function formalism in another file.

However this is what I have been working on, I create a pull request to discuss whether this new implementation is correct or not :)