### PR TITLE
enh: trying to make plots more customizable

### DIFF
--- a/Hubbard/plot/bandstructure.py
+++ b/Hubbard/plot/bandstructure.py
@@ -68,7 +68,7 @@ class Bandstructure(Plot):
                 self.axes.errorbar(lk, ev[0, :, i], yerr=scale*pdos[0, :, i], alpha=.4, color='Grey')
         # Add spin-up component to plot (top layer)
         self.axes.plot(lk, ev[0], color=c)
-        self.fig.gca().xaxis.set_ticks(xticks)
-        self.fig.gca().set_xticklabels(xticks_labels)
+        self.axes.xaxis.set_ticks(xticks)
+        self.axes.set_xticklabels(xticks_labels)
         # Adjust borders
         self.fig.subplots_adjust(left=0.2, top=.95, bottom=0.1, right=0.95)

--- a/Hubbard/plot/bonds.py
+++ b/Hubbard/plot/bonds.py
@@ -34,7 +34,7 @@ class BondOrder(GeometryPlot):
                 # intracell bond
                 x = [xr[0], xc[0]]
                 y = [xr[1], xc[1]]
-                plt.plot(x, y, c='k', ls='-', lw=4, solid_capstyle='round')
+                self.axes.plot(x, y, c='k', ls='-', lw=4, solid_capstyle='round')
             else:
                 # intercell bond
                 cell = H.geometry.sc.cell
@@ -48,7 +48,7 @@ class BondOrder(GeometryPlot):
                 R -= np.sign(P[j])*cell[j] # Subtract relevant lattice vector
                 x = [xr[0], xr[0]-R[0]/2]
                 y = [xr[1], xr[1]-R[1]/2]
-                plt.plot(x, y, c='k', ls='-', lw=4, solid_capstyle='round')
+                self.axes.plot(x, y, c='k', ls='-', lw=4, solid_capstyle='round')
             self.axes.text(sum(x)/2, sum(y)/2, r'%.3f'%BO[r, c], ha="center", va="center", rotation=15, size=6, bbox=bbox_props)
 
 

--- a/Hubbard/plot/plot.py
+++ b/Hubbard/plot/plot.py
@@ -5,23 +5,35 @@ from matplotlib.collections import PatchCollection
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 
+# Install font rc params
+plt.rc('text', usetex=True)
+plt.rc('font', family='Bitstream Vera Serif', size=16)
+
+
 class Plot(object):
 
     def __init__(self, **kwargs):
         # Figure size
         figsize = kwargs.get("figsize", (8, 6))
-        self.fig = plt.figure(figsize=figsize)
-        self.axes = plt.axes()
-        plt.rc('text', usetex=True)
-        plt.rc('font', family='Bitstream Vera Serif', size=16)
+        if "figure" in kwargs:
+            self.fig = kwargs["figure"]
+        else:
+            self.fig = plt.figure(figsize=figsize)
+        axes = self.fig.get_axes()
+        if len(axes) == 0:
+            self.axes = self.fig.add_subplot(1, 1, 1)
+        elif len(axes) == 1:
+            self.axes = axes[0]
 
     def savefig(self, fn):
-        plt.tight_layout()
+        self.fig.tight_layout()
         self.fig.savefig(fn)
-        print('Wrote', fn)
 
     def close(self):
-        plt.close('all')
+        # matplotlib does not have close method on Figure class
+        # weird.
+        self.fig.clear()
+        plt.close(self.fig)
 
     def set_title(self, title, fontsize=16):
         self.axes.set_title(title, size=fontsize)
@@ -42,7 +54,7 @@ class Plot(object):
         divider = make_axes_locatable(self.axes)
         cax = divider.append_axes(pos, size=size, pad=0.1)
         self.colorbar = plt.colorbar(layer, cax=cax)
-        plt.subplots_adjust(right=0.8)
+        self.fig.subplots_adjust(right=0.8)
 
     def legend(self, **kwargs):
         handles, labels = self.fig.gca().get_legend_handles_labels()
@@ -50,9 +62,6 @@ class Plot(object):
         labels, ids = np.unique(labels, return_index=True)
         handles = [handles[i] for i in ids]
         self.fig.legend(handles, labels, **kwargs)
-
-# Generate a dummy plot, this seems to avoid font issues with subsequent instances
-Plot()
 
 
 class GeometryPlot(Plot):

--- a/Hubbard/plot/spectrum.py
+++ b/Hubbard/plot/spectrum.py
@@ -21,7 +21,7 @@ class Spectrum(Plot):
             ev -= HubbardHamiltonian.midgap
             L = np.diagonal(L)
             lmax = max(max(L), lmax)
-            plt.plot(ev, L, 'rg'[ispin]+'.+'[ispin], label=[r'$\sigma=\uparrow$', r'$\sigma=\downarrow$'][ispin])
+            self.axes.plot(ev, L, 'rg'[ispin]+'.+'[ispin], label=[r'$\sigma=\uparrow$', r'$\sigma=\downarrow$'][ispin])
 
             if 'annotate' in kwargs:
                 if kwargs['annotate'] != False:
@@ -139,7 +139,7 @@ class DOS(Plot):
             self.legend()
         else:
             DOS = HubbardHamiltonian.DOS(egrid, eta=eta, spin=spin)
-            plt.plot(egrid, DOS, label='TDOS')
+            self.axes.plot(egrid, DOS, label='TDOS')
 
         self.set_xlabel(r'E-E$_\mathrm{midgap}$ [eV]')
         self.set_ylabel(r'DOS [1/eV]')


### PR DESCRIPTION
This partially fixes something for #69 

```python
fig = plt.figure()
for U in ...:
    ...
    p = plot.DOS(H, egrid, eta=1e-2, spin=[0], figure=fig)
    ...
p.savefig("all.png")
```
should *hopefully* work.

However, I think the problem is they way the `DOS(Plot)` class, and all the others are used.
Basically all they do is in their `__init__` routine, making them extremely static.

To me the `DOS(Plot)` class could just as well be this:
```python
def DOSPlot(..., **kwargs):
    plot = Plot(**kwargs)
    if np.any(sites):
        DOS = HubbardHamiltonian.PDOS(egrid, eta=eta, spin=spin)
        offset = 0.*np.average(DOS[sites[0]])
        for i, s in enumerate(sites):
            plot.axes.plot(egrid, DOS[s]+offset*i, label='site %i'%i)
        plot.legend()
    else:
        DOS = HubbardHamiltonian.DOS(egrid, eta=eta, spin=spin)
        plot.axes.plot(egrid, DOS, label='TDOS')

    plot.set_xlabel(r'E-E$_\mathrm{midgap}$ [eV]')
    plot.set_ylabel(r'DOS [1/eV]')
    return plot
```
Basically all your `Plot` sub-classes only uses the `Plot` class to hold the axes and figure, nothing more.

This is a bit counter-intuitive of what a class should do, I think. I think this is what is causing the confusing in #69?

I don't know how you else want this to be done. One could for instance do a `HubbardPlot` that does something like this:
```python
chrg = ChargeDifference(realspace=True)
sppol = SpinPolarization(realspace=True)
plot = HubbardPlot([chrg, sppol])
# now plot has 2 axes in one plot utility. To add a plot do
chrg.plot(HH, ext_geom, spin=0)
sppol(HH, ext_geom)
plot.savefig(...)
```
or something (note, this isn't carefully thought through, and perhaps not the best way).

But this would force the plotting work to be done in a separate `plot` method that does the heavy lifting and allows re-use of the same axes.
