### PR TITLE
Added comments

### DIFF
--- a/tutorials/MFH_01/run.ipynb
+++ b/tutorials/MFH_01/run.ipynb
@@ -7,7 +7,7 @@
    "outputs": [],
    "source": [
     "import sisl\n",
-    "import hubbard.hamiltonian as hh\n",
+    "import hubbard as hubb\n",
     "import hubbard.sp2 as sp2\n",
     "import hubbard.density as density\n",
     "import hubbard.plot as plot\n",
@@ -26,7 +26,7 @@
     "\n",
     "You can find the molecular geometry in the file `junction-2-2.XV`.\n",
     "\n",
-    "In the exercises section we will also use the `hubbard` package to find the converged solution for a system with periodic boundary conditions."
+    "In the exercises section we will also use the [`hubbard`](https://github.com/dipc-cc/hubbard) package to find the converged solution for a system with periodic boundary conditions."
    ]
   },
   {
@@ -35,7 +35,7 @@
    "source": [
     "### Getting started:\n",
     "\n",
-    "- We will start by building the tight-binding (TB) Hamiltonian for an sp2 carbon-based molecule, by first reading the geometry file using `sisl`. To build the TB Hamiltonian (which describes the kinetic part of the system's Hamiltonian) we will use the function from the `hubbard` package `sp2` that builds the TB `sisl.Hamiltonian` of an sp2 carbon system. In particulat, we will use the set of parameters `t1=2.7`,`t2=0.2` and `t3=0.18` eV to model this Hamiltonian.\n"
+    "We will start by building the tight-binding (TB) Hamiltonian for an sp2 carbon-based molecule, by first reading the geometry file using `sisl`. To build the TB Hamiltonian (which describes the kinetic part of the system's Hamiltonian) we will use the function from the `hubbard` package `sp2` that builds the TB `sisl.Hamiltonian` of an sp2 carbon system. In particular, we will use the set of parameters `t1=2.7`,`t2=0.2` and `t3=0.18` eV to model this Hamiltonian."
    ]
   },
   {
@@ -55,12 +55,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "- We will build the `HubbardHamiltonian` object, which will allow us to use the routines stored in this class to converge the mean field Hubbard Hamiltonian until we find the self-consistent solution. To model the interaction part (Hubbard term) we will use `U=3.5` eV. You can find the parameters used to build the full Hamiltonian (both the kinetic and interaction parts) in the [Supp. Material](https://www.nature.com/articles/s41467-018-08060-6#Sec12) of the [paper referenced above](https://www.nature.com/articles/s41467-018-08060-6).\n",
+    "We will build the `HubbardHamiltonian` object, which will allow us to use the routines stored in this class to converge the mean field Hubbard Hamiltonian until we find the self-consistent solution. To model the interaction part (Hubbard term) we will use `U=3.5` eV. You can find the parameters used to build the full Hamiltonian (both the kinetic and interaction parts) in the [Supp. Material](https://www.nature.com/articles/s41467-018-08060-6#Sec12) of the [paper referenced above](https://www.nature.com/articles/s41467-018-08060-6).\n",
     "\n",
     "Type:\n",
     "\n",
     "```\n",
-    "help(hh.HubbardHamiltonian)\n",
+    "help(hubb.HubbardHamiltonian)\n",
     "```\n",
     "for more information."
    ]
@@ -72,7 +72,7 @@
    "outputs": [],
    "source": [
     "# Build the HubbardHamiltonian object with U=3.5 at a temperature of kT~0 in units of the Boltzmann constant\n",
-    "HH = hh.HubbardHamiltonian(Hsp2, U=3.5, kT=1e-5)"
+    "HH = hubb.HubbardHamiltonian(Hsp2, U=3.5, kT=1e-5)"
    ]
   },
   {
@@ -81,7 +81,7 @@
    "source": [
     "##### Important note before we start the convergence process\n",
     "It is important that we initialize the convergence of the `HubbardHamiltonian` object by giving an initial spin-density that breaks the symmetry between the up- and down- spin channels. Otherwise the code *will not be able to find a solution*.\n",
-    "Furthermore, the closer the initial spin-denisities are from the self-consistent solution, the faster the code will find it."
+    "Furthermore, the closer the initial spin-densities are to the self-consistent solution, the faster the code will find it."
    ]
   },
   {
@@ -103,12 +103,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "- Now we can start the convergence until we find the self-consistent solution up to a desired tolerance (`tol`) by calling the `hh.HubbardHamiltonian.converge` method. This method needs of another method to tell the code how to build the spin-densities. For instance, to compute the spin-densities for TB Hamiltonians with finite or periodic boundary conditions, one could use the method `density.dm`. \n",
+    "Now we can start the convergence until we find the self-consistent solution up to a desired tolerance (`tol`) by calling the `hubb.HubbardHamiltonian.converge` method. This method needs of another method to tell the code how to build the spin-densities. For instance, to compute the spin-densities for TB Hamiltonians with finite or periodic boundary conditions, one could use the method `density.dm`. \n",
     "\n",
     "Type:\n",
     "\n",
     "```\n",
-    "help(hh.HubbardHamiltonian.converge)\n",
+    "help(hubb.HubbardHamiltonian.converge)\n",
     "```\n",
     "and/or\n",
     "\n",
@@ -147,8 +147,9 @@
    "source": [
     "# Save total energy\n",
     "E_0 =  HH.Etot\n",
+    "print(f\"Total energy = {E_0}\")\n",
     "\n",
-    "# Let's visualize some relevant physical quantities of the final result (this process make take a few seconds):\n",
+    "# Let's visualize some relevant physical quantities of the final result (this process may take a few seconds):\n",
     "p = plot.SpinPolarization(HH, colorbar=True, vmax=0.4, vmin=-0.4)\n",
     "p.annotate()"
    ]
@@ -180,7 +181,7 @@
     "Now compare the total energies, this will tell you which solution is the ground state.\n",
     "\n",
     "##### Extra material:\n",
-    "You can go to the [Supp. Material](https://www.nature.com/articles/s41467-018-08060-6#Sec12) of the [referenced paper above](https://www.nature.com/articles/s41467-018-08060-6), and try to reproduce other results, e.g. such as the singlet triplet transition curve as a function of the Coulomb parameter `U`, the waefunctions for each spin-channel, etc."
+    "You can go to the [Supp. Material](https://www.nature.com/articles/s41467-018-08060-6#Sec12) of the [referenced paper above](https://www.nature.com/articles/s41467-018-08060-6), and try to reproduce other results, e.g. such as the singlet triplet transition curve as a function of the Coulomb parameter `U`, the wavefunctions for each spin-channel, etc."
    ]
   },
   {

--- a/tutorials/MFH_02/run.ipynb
+++ b/tutorials/MFH_02/run.ipynb
@@ -7,7 +7,7 @@
    "outputs": [],
    "source": [
     "import sisl\n",
-    "import hubbard.hamiltonian as hh\n",
+    "import hubbard as hubb\n",
     "import hubbard.sp2 as sp2\n",
     "import hubbard.density as density\n",
     "import hubbard.plot as plot\n",
@@ -20,12 +20,12 @@
    "source": [
     "# Simulation of electron correlations in periodic systems \n",
     "\n",
-    "Let's try now to find the band structure of a correlated 1D system with periodic boundary conditions along a certain axis.\n",
+    "Let's try now to find the band structure of a correlated 1D system with periodic boundary condition.\n",
     "In this example we will reproduce the results of Ref. [Phys. Rev. B 81, 245402 (2010)](https://journals.aps.org/prb/abstract/10.1103/PhysRevB.81.245402).\n",
     "\n",
-    "Let's consider, for instance, the case of the zigzag graphene nanoribbon 16 C-atoms across width (which we will call 16-ZGNR) with the parameters of set D (see Table I of the [Ref. paper](https://journals.aps.org/prb/abstract/10.1103/PhysRevB.81.245402)). This is, `t1=2.7`, `t2=0.2`, `t3=0.18` eV for the kinetic part (TB Hamiltonian), and `U=2.0` eV for the interaction part (Hubbard term).\n",
+    "Consider, for instance, the case of the zigzag graphene nanoribbon 16 C-atoms across width (which we will call 16-ZGNR) with the parameters of set D (see Table I of the [Ref. paper](https://journals.aps.org/prb/abstract/10.1103/PhysRevB.81.245402)). This is, `t1=2.7`, `t2=0.2`, `t3=0.18` eV for the kinetic part (TB Hamiltonian), and `U=2.0` eV for the interaction part (Hubbard term).\n",
     "\n",
-    "- We need first to buld the geometry of the unit cell of the 16-ZGNR with appropiate cell dimensions to have periodicity, e.g., along the x-axis direction and no coupling in any other direction."
+    "First we build the geometry of the unit cell of the 16-ZGNR with appropiate cell dimensions to have periodicity, e.g., along the $x$-axis direction and no coupling in any other direction."
    ]
   },
   {
@@ -45,7 +45,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "- Now you have to build the TB Hamiltonian, just as in the case of example MFH_01. Again, you can make use of the function `sp2` of the `hubbard` package, which will return the `sisl.Hamiltonian` object that we need to build the  `hh.HubbardHamiltonian`."
+    "Now you have to build the TB Hamiltonian, just as in the case of example MFH_01. Again, you can make use of the function `sp2` of the `hubbard` package, which will return the `sisl.Hamiltonian` object that we need to build the  `hubb.HubbardHamiltonian`."
    ]
   },
   {
@@ -62,7 +62,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "- In this case, since the system has periodic boundary conditions, we need to find the self-consistent solution per *k-point*. To do so you just need to pass the argument `nkpt=[nkx, nky, nkz]` when creating the `hh.HubabrdHamiltonian(...)` object. This argument will set the number of k-points along each direction in which the Hamiltonian will be sampled in the k-space. I.e. if the system is periodic only along the x-axis, you should pass something like `nkpt=[nkx, 1, 1]`, where `nkx>1` (the larger this number is, the better the sampling and the slower the convergence process are)."
+    "In this case, since the system has periodic boundary conditions, we need to find the self-consistent solution per $\\mathbf k$-point. To do so you just need to pass the argument `nkpt=[nkx, nky, nkz]` when creating the `hubb.HubabrdHamiltonian(...)` object. This argument will set the number of $\\mathbf k$-points along each direction in which the Hamiltonian will be sampled in k-space. I.e. if the system is periodic only along the $x$-axis, you should pass something like `nkpt=[nkx, 1, 1]`, where `nkx>1` (the larger this number is, the better the sampling and the slower the convergence process are)."
    ]
   },
   {
@@ -72,23 +72,22 @@
    "outputs": [],
    "source": [
     "# Build the HubbardHamiltonian object using the U value from the reference paper\n",
-    "HH = hh.HubabrdHamiltonian(Hsp2, U=U, nkpt=[nkx, nky, nkz], kT=1e-5)"
+    "HH = hubb.HubbardHamiltonian(Hsp2, U=U, nkpt=[nkx, nky, nkz], kT=1e-5)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "- Before converging, you can plot the band structure of the system, e.g., by doing:\n",
-    "\n",
+    "- 1. Before converging, you can plot the band structure of the system, e.g., by doing:\n",
     "```\n",
     "p = plot.Bandstructure(...)\n",
     "```\n",
-    "  Fill the `(...)` with the name of the variable in which you stored the `hh.HubbardHamiltonian` object.\n",
+    "  Fill the `(...)` with the name of the variable in which you stored the `hubb.HubbardHamiltonian` object.\n",
     "  \n",
-    "- Now you can converge using the routine `HubbardHamiltonian.converge(...)`, just as in example [MFH_01](../MFH_01/run.ipynb). Remember to initialize the spin-densities before convergence!\n",
+    "- 2. Now you can converge using the routine `HubbardHamiltonian.converge(...)`, just as in example [MFH_1](../MFH_01/run.ipynb). Remember to initialize the spin-densities before convergence!\n",
     "\n",
-    "- Finally, you can visualize some relevant physical quantities, such as the spin-polarization per unit-cell and the band structure of the self-consistent solution.\n",
+    "- 3. Finally, you can visualize relevant physical quantities, such as the spin polarization per unit-cell and the band structure of the self-consistent solution. In exercise [MFH_1](../MFH_01/run.ipynb) there is an example of how to plot the spin polarization using the `hubbard` package. To plot the bandstructure of the converged Hamiltonian you can do the same as in 1., as now the self-consistent solution is stored in the `HubbardHamiltonian` object. For more information about plotting functionalities in the `hubbard` package you can type `help(plot)`.\n",
     "\n",
     "Now you can compare the bandstructure of the system for the pure TB Hamiltonian (before convergence) and of the self-consistent solution (after convergence).\n",
     "\n",

--- a/tutorials/MFH_03/run.ipynb
+++ b/tutorials/MFH_03/run.ipynb
@@ -7,7 +7,7 @@
    "outputs": [],
    "source": [
     "import sisl\n",
-    "import hubbard.hamiltonian as hh\n",
+    "import hubbard as hubb\n",
     "import hubbard.sp2 as sp2\n",
     "import hubbard.density as density\n",
     "from hubbard.negf import NEGF\n",
@@ -25,7 +25,7 @@
     "\n",
     "Here we will reproduce the results presented in [Phys. Rev. B 81, 245402 (2010)](https://journals.aps.org/prb/abstract/10.1103/PhysRevB.81.245402) for the system shown in Fig. 3(a). This is, a zigzag graphene nanoribbon with a defect created by removing certain atoms in the central region. This open-quantum system is composed by a central region that contains the defect coupled to two semi-infinite leads or electrodes (left and right).\n",
     "\n",
-    "We will focus on the equilibrium situation, therefore the temperature and chemical potentials of the electrodes *must coincide*. The complex contour that we use to integrate the density matrix in the `hubbard.NEGF` class is extracted from a [Transiesta](https://launchpad.net/siesta) calculation performed for a temperature of `kT=0.025` eV, which we will set as common for all the composing element calculations.\n"
+    "We will focus on the equilibrium situation, therefore the temperature and chemical potentials of the electrodes *must coincide*. The complex contour that we use to integrate the density matrix in the `hubbard.NEGF` class is extracted from a [TranSiesta](https://gitlab.com/siesta/-project/siesta) calculation performed for a temperature of `kT=0.025` eV, which we will set as common for all the composing element calculations.\n"
    ]
   },
   {
@@ -44,7 +44,7 @@
    "metadata": {},
    "source": [
     "#### 1) Compute the electrodes \n",
-    "We will start by building the tight-binding (TB) Hamiltonian for the graphene nanoribbons, which compose the electrodes (periodic boundary conditions). Then we will find their self-consistent solution by using the `hubbard` package. Look into excercise [MFH_02](../MFH_02/run.ipynb)"
+    "We will start by building the tight-binding (TB) Hamiltonian for the graphene nanoribbons, which compose the electrodes (periodic boundary conditions). Then we will find their self-consistent solution by using the `hubbard` package. Look into excercise [MFH_2](../MFH_02/run.ipynb)"
    ]
   },
   {
@@ -62,7 +62,7 @@
     "H_elec = sp2(ZGNR, t1=2.7, t2=0.2, t3=0.18, s1=0, s2=0, s3=0)\n",
     "\n",
     "# Build the HubbardHamiltonian object for the periodic system:\n",
-    "MFH_elec = hh.HubbardHamiltonian(..., U=U, kT=kT)\n",
+    "MFH_elec = hubb.HubbardHamiltonian(..., U=U, kT=kT)\n",
     "\n",
     "# Initialize electrodes spin density\n",
     "MFH_elec.set_polarization([0], dn=[9])\n",
@@ -75,7 +75,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "- Let's plot the spin polarization of the unit cel to check out the self-consistent solution"
+    "Plot the spin polarization of the unit cell to check out the self-consistent solution."
    ]
   },
   {
@@ -121,11 +121,15 @@
    "source": [
     "#### 3) Obtain the spin-density for the open-quantum system\n",
     "\n",
-    "- Create the HubbardHamiltonian object for the device system\n",
+    "- Create the `HubbardHamiltonian` object for the device system\n",
     "\n",
-    "The `NEGF` is a class of the `hubbard` package, therefore the first step is to:\n",
-    "- Create the NEGF object\n",
-    "- Converge using the methods stored in the negf class"
+    "The `NEGF` is a class of the `hubbard` package, therefore the first step is to create the `NEGF` object for the device and electrodes. To build this object one has to pass the following arguments:\n",
+    "\n",
+    "- the non-converged `HubbardHamiltonian` object of the device\n",
+    "- a list that contains all the electrodes in the device with its semi-infinite direction, e.g. `[(ElecA, DirA), (ElecB, DirB), ...]`. Where `ElecA`, `ElecB` stand for the names of the variables of the `HubbardHamiltonian` of the *converged* electrodes' Hamiltonians, while `DirA`, `DirB` stand for the semi-infinite direction of each electrode. Following `sisl` notation these directions can be: `-A,+A,-B,+B,-C,+C` for semi-infinite direction along the first, second or third axes (`A,B,C`), respectively. The sign indicates the sense towards the semi-infinite lead grows.\n",
+    "- the atomic positions of where the electrodes are mapped in the device.\n",
+    "\n",
+    "Then you can converge the Hamiltonian of this open quantum system by using the methods of the `negf` class."
    ]
   },
   {
@@ -135,9 +139,9 @@
    "outputs": [],
    "source": [
     "# Create the HubbardHamiltonian for the device\n",
-    "H_dev = hh.HubbardHamiltonian(...)\n",
+    "H_dev = hubb.HubbardHamiltonian(...)\n",
     "\n",
-    "# Define the electrode atomic positions inside the device (first and last blocks):\n",
+    "# Define the electrode atomic positions inside the device (in this case, the first and last blocks):\n",
     "elec_indx = [range(len(H_elec)), range(-len(HC.H), 0)]\n",
     "\n",
     "# Create the NEGF object for the device and electrodes. This class will allow you to use the methods\n",
@@ -155,7 +159,7 @@
     "## Try it yourself\n",
     "\n",
     "For these systems and using the NEGF formalism, we are able to find the transmission probabilities per spin channel.\n",
-    "Look into example [TB_04](https://github.com/zerothi/ts-tbt-sisl-tutorial/blob/master/TB_04/run.ipynb) for more information about how [TBtrans](https://launchpad.net/siesta) and [sisl](https://sisl.readthedocs.io/en/v0.10.0/api.html) can be combined."
+    "Look into example [TB_04](https://github.com/zerothi/ts-tbt-sisl-tutorial/blob/master/TB_04/run.ipynb) for more information about how [TBtrans](https://gitlab.com/siesta/-project/siesta) and [sisl](https://zerothi.github.io/sisl) can be combined."
    ]
   },
   {


### PR DESCRIPTION
I changed a few things here and there and added some comments.

Instead of doing `import hubbard.hamiltonian as hh ; hh.HubbardHamiltonian` it may be easier to just do `import hubbard as hubb` (or whatever name you prefer) and the just `hubb.HubbardHamiltonian`.
The abstraction of having the double nested levels is a bit confusing.
The same goes for many of the other imports, i.e. use `hubb.plot.BandStructure` instead and same for density. It clarifies where the routines belong. (note to self, I also need to clean this up in my own tutorials ;))

But all looks good, I changed all all imports of the Hamiltonian to the above suggestion. But please adjust.

Note that the notebooks are not cleaned.... Yet ;)

