### PR TITLE
Rename variable `dm` for `occ` (occupations)

### DIFF
--- a/examples/molecules/anthracenes/compute.py
+++ b/examples/molecules/anthracenes/compute.py
@@ -3,7 +3,7 @@ import hubbard.sp2 as sp2
 import hubbard.plot as plot
 import sys
 import numpy as np
-import hubbard.density as dm
+import hubbard.density as dens
 import sisl
 
 # Build sisl Geometry object
@@ -32,7 +32,7 @@ for u in np.linspace(0.0, 4.0, 5):
         H.random_density()
         H.set_polarization([1, 6, 15]) # polarize lower zigzag edge
     mixer.clear()
-    dn = H.converge(dm.dm_insulator, mixer=mixer)
+    dn = H.converge(dens.calc_occ_insulator, mixer=mixer)
     eAFM = H.Etot
     H.write_density(mol_file+'.nc')
 
@@ -48,7 +48,7 @@ for u in np.linspace(0.0, 4.0, 5):
     except:
         H.random_density()
     mixer.clear()
-    dn = H.converge(dm.dm_insulator, mixer=mixer)
+    dn = H.converge(dens.calc_occ_insulator, mixer=mixer)
     eFM = H.Etot
     H.write_density(mol_file+'.nc')
 

--- a/examples/molecules/clar-goblet/compute_FM-AFM.py
+++ b/examples/molecules/clar-goblet/compute_FM-AFM.py
@@ -16,7 +16,7 @@ Hsp2 = sp2(mol, t1=2.7, t2=0.2, t3=.18, dim=2)
 H = hh.HubbardHamiltonian(Hsp2)
 H.random_density()
 H.set_polarization(up=[6], dn=[28])
-dm_AFM = H.dm
+occ_AFM = H.occ
 
 f = open('FM-AFM.dat', 'w')
 
@@ -30,12 +30,12 @@ for u in np.arange(5, 0, -0.25):
     # AFM case first
     success = H.read_density('clar-goblet.nc') # Try reading, if we already have density on file
     if not success:
-        H.dm = dm_AFM.copy()
+        H.occ = occ_AFM.copy()
 
-    dn = H.converge(density.dm_insulator, tol=1e-10, mixer=mixer)
+    dn = H.converge(density.calc_occ_insulator, tol=1e-10, mixer=mixer)
     eAFM = H.Etot
     H.write_density('clar-goblet.nc')
-    dm_AFM = H.dm.copy()
+    occ_AFM = H.occ.copy()
 
     if u == 3.5:
         p = plot.SpinPolarization(H, colorbar=True, vmax=0.4, vmin=-0.4)
@@ -49,7 +49,7 @@ for u in np.arange(5, 0, -0.25):
         H.random_density()
         H.set_polarization(up=[6, 28])
     mixer.clear()
-    dn = H.converge(density.dm_insulator, tol=1e-10, mixer=mixer)
+    dn = H.converge(density.calc_occ_insulator, tol=1e-10, mixer=mixer)
     eFM = H.Etot
     H.write_density('clar-goblet.nc')
 

--- a/examples/molecules/kondo-paper/Type-1/fig3.py
+++ b/examples/molecules/kondo-paper/Type-1/fig3.py
@@ -1,7 +1,7 @@
 import hubbard.hamiltonian as hh
 import hubbard.plot as plot
 import hubbard.sp2 as sp2
-import hubbard.density as dm
+import hubbard.density as density
 import sys
 import numpy as np
 import sisl
@@ -35,7 +35,7 @@ success = H.read_density('fig3_type1.nc') # Try reading, if we already have dens
 if not success:
     H.set_polarization([23])
 mixer = sisl.mixing.PulayMixer(0.7, history=7)
-H.converge(dm.dm_insulator, mixer=mixer)
+H.converge(density.calc_occ_insulator, mixer=mixer)
 H.write_density('fig3_type1.nc')
 p = plot.SpinPolarization(H, ext_geom=mol, vmax=0.20)
 p.savefig('fig3_pol.pdf')

--- a/examples/molecules/kondo-paper/fig_S11-S13.py
+++ b/examples/molecules/kondo-paper/fig_S11-S13.py
@@ -1,7 +1,7 @@
 import hubbard.hamiltonian as hh
 import hubbard.plot as plot
 import hubbard.sp2 as sp2
-import hubbard.density as dm
+import hubbard.density as density
 import sys
 import numpy as np
 
@@ -29,7 +29,7 @@ for u in [0.0, 3.5]:
         if not success:
             H.set_polarization([77], dn=[23])
         mixer.clear()
-        H.converge(dm.dm_insulator, mixer=mixer)
+        H.converge(density.calc_occ_insulator, mixer=mixer)
         H.write_density('fig_S11-S13.nc')
 
     # Plot Eigenspectrum

--- a/examples/molecules/kondo-paper/fig_S15.py
+++ b/examples/molecules/kondo-paper/fig_S15.py
@@ -1,6 +1,6 @@
 import hubbard.hamiltonian as hh
 import hubbard.sp2 as sp2
-import hubbard.density as dm
+import hubbard.density as density
 import hubbard.plot as plot
 import sys
 import numpy as np
@@ -27,7 +27,7 @@ for u in np.linspace(0.0, 1.4, 15):
     success = H.read_density('fig_S15.nc') # Try reading, if we already have density on file
 
     mixer.clear()
-    dn = H.converge(dm.dm_insulator, mixer=mixer, tol=1e-6)
+    dn = H.converge(density.calc_occ_insulator, mixer=mixer, tol=1e-6)
     eAFM = H.Etot
     H.write_density('fig_S15.nc')
 
@@ -37,7 +37,7 @@ for u in np.linspace(0.0, 1.4, 15):
     success = H.read_density('fig_S15.nc') # Try reading, if we already have density on file
 
     mixer.clear()
-    dn = H.converge(dm.dm_insulator, mixer=mixer, tol=1e-6)
+    dn = H.converge(density.calc_occ_insulator, mixer=mixer, tol=1e-6)
     eFM = H.Etot
     H.write_density('fig_S15.nc')
 

--- a/examples/open/benchmarks/AGNR-constriction/setup.py
+++ b/examples/open/benchmarks/AGNR-constriction/setup.py
@@ -35,7 +35,7 @@ if not success:
     MFH_elec.random_density()
 
 # Converge Electrode Hamiltonians
-dn = MFH_elec.converge(density.dm, mixer=mixer)
+dn = MFH_elec.converge(density.calc_occ, mixer=mixer)
 
 # Write also densities for future calculations
 MFH_elec.write_density('elec_density.nc')
@@ -64,16 +64,16 @@ success = MFH_HC.read_density('HC_density.nc')
 if not success:
     # Converge without OBC to have initial density
     mixer.clear()
-    MFH_HC.converge(density.dm, tol=1e-5, mixer=mixer)
+    MFH_HC.converge(density.calc_occ, tol=1e-5, mixer=mixer)
 
 # First create NEGF object
 negf = NEGF(MFH_HC, [(MFH_elec, '-A'), (MFH_elec, '+A')], elec_indx)
 # Converge using Green's function method to obtain the densities
 mixer.clear()
-dn = MFH_HC.converge(negf.dm_open, steps=1, tol=1e-5, mixer=mixer, print_info=True)
+dn = MFH_HC.converge(negf.calc_occ_open, steps=1, tol=1e-5, mixer=mixer, print_info=True)
 
 MFH_HC.H.write('MFH_HC.nc', Ef=negf.Ef)
-print('Nup, Ndn: ', MFH_HC.dm.sum(axis=1))
+print('Nup, Ndn: ', MFH_HC.occ.sum(axis=1))
 # Write also densities for future calculations
 MFH_HC.write_density('HC_density.nc')
 # Plot spin polarization of electrodes

--- a/examples/open/benchmarks/ZGNR-constriction/setup.py
+++ b/examples/open/benchmarks/ZGNR-constriction/setup.py
@@ -36,7 +36,7 @@ if not success:
     MFH_elec.set_polarization([0], dn=[9])
 
 # Converge Electrode Hamiltonians
-dn = MFH_elec.converge(density.dm, mixer=mixer)
+dn = MFH_elec.converge(density.calc_occ, mixer=mixer)
 # Write also densities for future calculations
 MFH_elec.write_density('elec_density.nc')
 # Plot spin polarization of electrodes
@@ -65,14 +65,14 @@ if not success:
     # Get initial spin-densities with PBC to speed up the following convergence with OBC
     DM = MFH_elec.tile(16, axis=0).DM
     DM = DM.remove([67, 68, 69, 72, 73, 74, 77, 78, 79, 82, 83, 84, 87, 88, 89])
-    MFH_HC.set_dm(DM)
+    MFH_HC.set_DM(DM)
 
 # First create NEGF object
 negf = NEGF(MFH_HC, [(MFH_elec, '-A'), (MFH_elec, '+A')], elec_indx, V=0.1)
 mixer.clear()
-dn = MFH_HC.converge(negf.dm_open, steps=1, tol=1e-5, mixer=mixer, func_args={'qtol': 1e-4}, print_info=True)
+dn = MFH_HC.converge(negf.calc_occ_open, steps=1, tol=1e-5, mixer=mixer, func_args={'qtol': 1e-4}, print_info=True)
 
-print('Nup, Ndn: ', MFH_HC.dm.sum(axis=1))
+print('Nup, Ndn: ', MFH_HC.occ.sum(axis=1))
 # Write also densities for future calculations
 MFH_HC.write_density('HC_density.nc')
 # Plot spin polarization of electrodes

--- a/examples/periodic/benchmarks/compute.py
+++ b/examples/periodic/benchmarks/compute.py
@@ -23,7 +23,7 @@ for i, geom in enumerate([agnr, zgnr]):
     # Start with random densities
     H.random_density()
     mixer.clear()
-    dn = H.converge(density.dm, mixer=mixer, print_info=True)
+    dn = H.converge(density.calc_occ, mixer=mixer, print_info=True)
 
     # Plot banstructure of Hubbard Hamiltonian
     p = plot.Bandstructure(H, ymax=3)

--- a/hubbard/__init__.py
+++ b/hubbard/__init__.py
@@ -15,7 +15,7 @@ Self Consistent field class
    :toctree:
 
     HubbardHamiltonian
-    dm
+    occ
     NEGF
 
 Read and write in binary files

--- a/hubbard/density.py
+++ b/hubbard/density.py
@@ -2,10 +2,10 @@ import numpy as np
 from numpy import einsum, conj
 import sisl
 
-__all__ = ['dm', 'dm_insulator']
+__all__ = ['calc_occ', 'calc_occ_insulator']
 
 
-def dm(H, q):
+def calc_occ(H, q):
     r""" General method to obtain the spin-densities for periodic or finite systems at a given temperature
 
     It obtains the densities from the direct diagonalization of the Hamiltonian (``H.H``) taking into account
@@ -65,7 +65,7 @@ def dm(H, q):
     return ni, Etot
 
 
-def dm_insulator(H, q):
+def calc_occ_insulator(H, q):
     """ Method to obtain the spin-densities only for the corner case for *insulators* at *T=0* """
     ni = np.zeros((2, H.sites))
     Etot = 0

--- a/hubbard/ncsile.py
+++ b/hubbard/ncsile.py
@@ -17,19 +17,19 @@ class ncSilehubbard(sisl.SileCDF):
         g = self.groups[group]
 
         # Read densities
-        dm = g.variables['dm'][:]
-        return dm
+        occ = g.variables['occ'][:]
+        return occ
 
-    def write_density(self, infolabel, group, dm):
+    def write_density(self, infolabel, group, occ):
         # Create group
         g = self._crt_grp(self, group)
         g.info = infolabel
 
         # Create dimensions
-        self._crt_dim(self, 'ncomp', dm.shape[0])
-        self._crt_dim(self, 'norb', dm.shape[1])
+        self._crt_dim(self, 'ncomp', occ.shape[0])
+        self._crt_dim(self, 'norb', occ.shape[1])
 
-        # Write variable dm
-        v = self._crt_var(g, 'dm', ('f8', 'f8'), ('ncomp', 'norb'))
+        # Write variable occ
+        v = self._crt_var(g, 'occ', ('f8', 'f8'), ('ncomp', 'norb'))
         v.info = 'Densities'
-        g.variables['dm'][:] = dm
+        g.variables['occ'][:] = occ

--- a/hubbard/negf.py
+++ b/hubbard/negf.py
@@ -183,7 +183,7 @@ class NEGF:
                         # And for each point in the Neq CC
                         self._cc_neq_SE[spin][ic][i] = se.self_energy(cc, spin=spin)
 
-    def dm_open(self, H, q, qtol=1e-5):
+    def calc_occ_open(self, H, q, qtol=1e-5):
         """
         Method to compute the spin densities from the Neq Green's function
 

--- a/hubbard/plot/charge.py
+++ b/hubbard/plot/charge.py
@@ -41,7 +41,7 @@ class Charge(GeometryPlot):
         if not isinstance(spin, list):
             spin = [spin]
 
-        charge = HubbardHamiltonian.dm[spin].sum(axis=0)
+        charge = HubbardHamiltonian.occ[spin].sum(axis=0)
 
         if realspace:
             self.__realspace__(charge, density=True, **kwargs)
@@ -81,7 +81,7 @@ class ChargeDifference(GeometryPlot):
         super().__init__(HubbardHamiltonian.geometry, ext_geom=ext_geom, **kwargs)
 
         # Compute total charge on each site, subtract neutral atom charge
-        charge = HubbardHamiltonian.dm.sum(0)
+        charge = HubbardHamiltonian.occ.sum(0)
         for ia in HubbardHamiltonian.geometry:
             charge[ia] -= HubbardHamiltonian.geometry.atoms[ia].Z-5
 
@@ -120,7 +120,7 @@ class SpinPolarization(GeometryPlot):
         super().__init__(HubbardHamiltonian.geometry, ext_geom=ext_geom, **kwargs)
 
         # Compute charge difference between up and down channels
-        charge = np.diff(HubbardHamiltonian.dm[[1, 0]], axis=0).ravel()
+        charge = np.diff(HubbardHamiltonian.occ[[1, 0]], axis=0).ravel()
 
         if realspace:
             self.__realspace__(charge, density=True, **kwargs)

--- a/hubbard/tests/test_hamiltonian.py
+++ b/hubbard/tests/test_hamiltonian.py
@@ -2,7 +2,7 @@ import pytest
 
 import hubbard.hamiltonian as hh
 import hubbard.sp2 as sp2
-import hubbard.density as dm
+import hubbard.density as density
 import sisl
 
 
@@ -12,6 +12,6 @@ def test_quick():
     Hsp2 = sp2(molecule)
     H = hh.HubbardHamiltonian(Hsp2, U=3.5)
     H.random_density()
-    dn = H.iterate(dm.dm_insulator, mixer=sisl.mixing.LinearMixer())
+    dn = H.iterate(density.calc_occ_insulator, mixer=sisl.mixing.LinearMixer())
     H.write_density('test.nc')
     H.write_initspin('test.fdf')

--- a/tests/test-hubbard-open.py
+++ b/tests/test-hubbard-open.py
@@ -23,7 +23,7 @@ MFH_elec = hh.HubbardHamiltonian(H_elec, U=U, nkpt=[102, 1, 1], kT=kT)
 # Start with random densities
 MFH_elec.random_density()
 # Converge Electrode Hamiltonians
-dn = MFH_elec.converge(density.dm, mixer=sisl.mixing.PulayMixer(weight=.7, history=7), tol=1e-10)
+dn = MFH_elec.converge(density.calc_occ, mixer=sisl.mixing.PulayMixer(weight=.7, history=7), tol=1e-10)
 
 # Central region is a repetition of the electrodes without PBC
 HC = H_elec.tile(3, axis=0)
@@ -38,20 +38,20 @@ MFH_HC = hh.HubbardHamiltonian(HC.H, DM=MFH_elec.DM.tile(3, axis=0), U=U, kT=kT)
 # First create NEGF object
 negf = NEGF(MFH_HC, [(MFH_elec, '-A'), (MFH_elec, '+A')], elec_indx)
 # Converge using Green's function method to obtain the densities
-dn = MFH_HC.converge(negf.dm_open, steps=1, mixer=sisl.mixing.PulayMixer(weight=.1), tol=0.1)
-dn = MFH_HC.converge(negf.dm_open, steps=1, mixer=sisl.mixing.PulayMixer(weight=1., history=7), tol=1e-6, print_info=True)
+dn = MFH_HC.converge(negf.calc_occ_open, steps=1, mixer=sisl.mixing.PulayMixer(weight=.1), tol=0.1)
+dn = MFH_HC.converge(negf.calc_occ_open, steps=1, mixer=sisl.mixing.PulayMixer(weight=1., history=7), tol=1e-6, print_info=True)
 
-assert abs(MFH_HC.dm[0].sum() - MFH_HC.q[0]) < 1e-5
-assert abs(MFH_HC.dm[1].sum() - MFH_HC.q[1]) < 1e-5
+assert abs(MFH_HC.occ[0].sum() - MFH_HC.q[0]) < 1e-5
+assert abs(MFH_HC.occ[1].sum() - MFH_HC.q[1]) < 1e-5
 print('MFH-NEGF Etot = {:10.5f}'.format(MFH_HC.Etot))
 
 # Reference test for total energy
 HC_periodic = H_elec.tile(3, axis=0)
 MFH_HC_periodic = hh.HubbardHamiltonian(HC_periodic.H, DM=MFH_elec.DM.tile(3, axis=0), U=U, nkpt=[int(102/3), 1, 1], kT=kT)
-dn = MFH_HC_periodic.converge(density.dm)
+dn = MFH_HC_periodic.converge(density.calc_occ)
 
-assert abs(MFH_HC_periodic.dm[0].sum() - MFH_HC_periodic.q[0]) < 1e-7
-assert abs(MFH_HC_periodic.dm[1].sum() - MFH_HC_periodic.q[1]) < 1e-7
+assert abs(MFH_HC_periodic.occ[0].sum() - MFH_HC_periodic.q[0]) < 1e-7
+assert abs(MFH_HC_periodic.occ[1].sum() - MFH_HC_periodic.q[1]) < 1e-7
 print('MFH-PER Etot = {:10.5f}'.format(MFH_HC_periodic.Etot))
 print('Diff:')
 print(MFH_HC_periodic.Etot - MFH_HC.Etot)

--- a/tests/test-hubbard-plots.py
+++ b/tests/test-hubbard-plots.py
@@ -20,7 +20,7 @@ p.savefig('bondHoppings.pdf')
 
 H = hh.HubbardHamiltonian(H_mol, U=3.5)
 H.read_density('mol-ref/density.nc')
-H.iterate(dens.dm_insulator)
+H.iterate(dens.calc_occ_insulator)
 
 p = plot.Charge(H, ext_geom=molecule, colorbar=True)
 p.savefig('chg.pdf')

--- a/tests/test-hubbard-quantitative.py
+++ b/tests/test-hubbard-quantitative.py
@@ -15,7 +15,7 @@ molecule.sc.set_nsc([1, 1, 1])
 Hsp2 = sp2(molecule)
 H = hh.HubbardHamiltonian(Hsp2, U=3.5)
 H.read_density('mol-ref/density.nc')
-H.iterate(dens.dm_insulator, mixer=sisl.mixing.LinearMixer())
+H.iterate(dens.calc_occ_insulator, mixer=sisl.mixing.LinearMixer())
 
 # Determine reference values for the tests
 ev0, evec0 = H.eigh(eigvals_only=False, spin=0)
@@ -23,7 +23,7 @@ Etot0 = 1 * H.Etot
 
 mixer = sisl.mixing.PulayMixer(0.7, history=7)
 
-for m in [dens.dm_insulator, dens.dm]:
+for m in [dens.calc_occ_insulator, dens.calc_occ]:
     # Reset density and iterate
     H.random_density()
     mixer.clear()
@@ -56,9 +56,9 @@ if True:
     H.kT = 0.025
     H.random_density()
     mixer.clear()
-    dn = H.converge(dens.dm, tol=1e-10, steps=10, mixer=mixer)
+    dn = H.converge(dens.calc_occ, tol=1e-10, steps=10, mixer=mixer)
     Etot0 = H.Etot
-    dm = 1 * H.dm
+    occ = 1 * H.occ
 
     # Obtain DOS for the finite molecule with Lorentzian distribution
     egrid = np.linspace(-1, 1, 50)
@@ -74,9 +74,9 @@ if True:
     negf.Ef =  H.find_midgap()
     negf.eta = 1e-2
     mixer.clear()
-    ddm = H.converge(negf.dm_open, mixer=mixer, tol=1e-10, func_args={'qtol': 1e-4}, steps=1, print_info=True)
+    docc = H.converge(negf.calc_occ_open, mixer=mixer, tol=1e-10, func_args={'qtol': 1e-4}, steps=1, print_info=True)
     print('Total energy difference: %.4e eV' % (Etot0 - H.Etot))
-    print('Density difference (up, dn): (%.4e, %.4e)' % (max(abs(H.dm[0] - dm[0])), max(abs(H.dm[1] - dm[1]))))
+    print('Density difference (up, dn): (%.4e, %.4e)' % (max(abs(H.occ[0] - occ[0])), max(abs(H.occ[1] - occ[1]))))
 
     # Plot DOS calculated from the diagonalization and the WBL with gamma=0
     H.H.shift(-negf.Ef)

--- a/tests/test-hubbard-quick.py
+++ b/tests/test-hubbard-quick.py
@@ -1,27 +1,27 @@
 import hubbard.hamiltonian as hh
 import hubbard.sp2 as sp2
-import hubbard.density as dm
+import hubbard.density as dens
 import sisl
 
 # Build sisl Geometry object
 molecule = sisl.get_sile('mol-ref/mol-ref.XV').read_geometry()
 molecule.sc.set_nsc([1, 1, 1])
 
-print('1. Run one iteration with dm_insulator')
+print('1. Run one iteration with calc_occ_insulator')
 Hsp2 = sp2(molecule)
 H = hh.HubbardHamiltonian(Hsp2, U=3.5)
 H.random_density()
-dn = H.iterate(dm.dm_insulator, mixer=sisl.mixing.LinearMixer())
+dn = H.iterate(dens.calc_occ_insulator, mixer=sisl.mixing.LinearMixer())
 print('   dn, Etot: ', dn, H.Etot, '\n')
 
 print('2. Run one iteration with data from ncfile')
 H.read_density('mol-ref/density.nc')
-dn = H.iterate(dm.dm_insulator, mixer=sisl.mixing.LinearMixer())
+dn = H.iterate(dens.calc_occ_insulator, mixer=sisl.mixing.LinearMixer())
 etot = 1 * H.Etot
 print('   dn, Etot: ', dn, etot, '\n')
 
-print('3. Run one iteration with dm')
-d = H.iterate(dm.dm, mixer=sisl.mixing.LinearMixer())
+print('3. Run one iteration with calc_occ')
+d = H.iterate(dens.calc_occ, mixer=sisl.mixing.LinearMixer())
 e = H.Etot
 print('   dn, dEtot: ', d - dn, e - etot, '\n')
 

--- a/tests/test-transmission-open.py
+++ b/tests/test-transmission-open.py
@@ -24,7 +24,7 @@ MFH_elec = hh.HubbardHamiltonian(H_elec, U=U, nkpt=[102, 1, 1], kT=kT)
 MFH_elec.random_density()
 MFH_elec.set_polarization([0], dn=[-1]) # Ensure we break symmetry
 # Converge Electrode Hamiltonians
-dn = MFH_elec.converge(density.dm, mixer=sisl.mixing.PulayMixer(weight=.7, history=7), tol=1e-10)
+dn = MFH_elec.converge(density.calc_occ, mixer=sisl.mixing.PulayMixer(weight=.7, history=7), tol=1e-10)
 
 dist = sisl.get_distribution('fermi_dirac', smearing=kT)
 Ef_elec = MFH_elec.H.fermi_level(MFH_elec.mp, q=MFH_elec.q, distribution=dist)
@@ -46,9 +46,9 @@ MFH_HC = hh.HubbardHamiltonian(HC.H, DM=MFH_elec.DM.tile(3, axis=0), U=U, kT=kT)
 # First create NEGF object
 negf = NEGF(MFH_HC, [(MFH_elec, '-A'), (MFH_elec, '+A')], elec_indx)
 # Converge using Green's function method to obtain the densities
-dn = MFH_HC.converge(negf.dm_open, steps=1, mixer=sisl.mixing.PulayMixer(weight=.1), tol=0.1)
-dn = MFH_HC.converge(negf.dm_open, steps=1, mixer=sisl.mixing.PulayMixer(weight=1., history=7), tol=1e-6, print_info=True)
-print('Nup, Ndn: ', MFH_HC.dm.sum(axis=1))
+dn = MFH_HC.converge(negf.calc_occ_open, steps=1, mixer=sisl.mixing.PulayMixer(weight=.1), tol=0.1)
+dn = MFH_HC.converge(negf.calc_occ_open, steps=1, mixer=sisl.mixing.PulayMixer(weight=1., history=7), tol=1e-6, print_info=True)
+print('Nup, Ndn: ', MFH_HC.occ.sum(axis=1))
 
 # Shift device with its Fermi level and write nc file
 MFH_HC.H.write('MFH_HC.nc', Ef=negf.Ef)


### PR DESCRIPTION
Previously we had `dm` to name the variable that stores the Mulliken populations. I think that this name is not very intuitive to understand what it actually is. I renamed this variable (and the names of the methods that obtain it in all classes) as `occ` (for occupations). I'm open to other suggestions too! Also if you think that any other variable is not very intuitive, this can be a nice chance to discuss it :-)