### PR TITLE
Allow to read density without matching hash

### DIFF
--- a/hubbard/hamiltonian.py
+++ b/hubbard/hamiltonian.py
@@ -389,11 +389,9 @@ class HubbardHamiltonian(object):
             netCDF4 group
         """
         if os.path.isfile(fn):
-            fh = nc.get_sile(fn, mode=mode)
-            if group is not None:
-                if group in fh.groups:
-                    self.n = fh.read_density(group)
-            else:
+            fh = nc.ncSilehubbard(fn, mode=mode)
+            self.n = fh.read_density(group=group)
+            if isinstance(self.n, list):
                 warnings.warn(f'Groups found in {fn}, using the density from the first one')
                 # Read only the first element from the list
                 self.n = fh.read_density()[0]
@@ -413,7 +411,7 @@ class HubbardHamiltonian(object):
         """
         if not os.path.isfile(fn):
             mode = 'w'
-        fh = nc.get_sile(fn, mode=mode)
+        fh = nc.ncSilehubbard(fn, mode=mode)
         fh.write_density(self.n, self.U, self.kT, group)
 
     def write_initspin(self, fn, ext_geom=None, spinfix=True, mode='a', eps=0.1):

--- a/hubbard/hamiltonian.py
+++ b/hubbard/hamiltonian.py
@@ -373,7 +373,7 @@ class HubbardHamiltonian(object):
         """
         self.H.shift(E)
 
-    def __hash__(self):
+    def get_hash(self):
         return hashlib.md5((self.q.tostring()+np.array([self.U]).tostring()+np.array([self.kT]).tostring()+self._hash_base)).hexdigest()[:7]
 
     def read_density(self, fn, mode='r', group=None):

--- a/hubbard/hamiltonian.py
+++ b/hubbard/hamiltonian.py
@@ -385,7 +385,7 @@ class HubbardHamiltonian(object):
             name of the file that is going to read from
         mode: str, optional
             mode in which the file is opened
-        group: optional
+        group: str, optional
             netCDF4 group
         """
         if os.path.isfile(fn):
@@ -408,7 +408,8 @@ class HubbardHamiltonian(object):
             name of the file in which the densities are going to be stored
         mode: str, optional
             mode in which the file is opened
-        group: optional
+        group: str, optional
+            netCDF4 group
         """
         if not os.path.isfile(fn):
             mode = 'w'

--- a/hubbard/hamiltonian.py
+++ b/hubbard/hamiltonian.py
@@ -393,7 +393,7 @@ class HubbardHamiltonian(object):
             netCDF4 group
         """
         if os.path.isfile(fn):
-            fh = nc.ncSilehubbard(fn, mode=mode)
+            fh = nc.ncSileHubbard(fn, mode=mode)
             self.n = fh.read_density(group=group)
             if isinstance(self.n, list):
                 warnings.warn(f'Groups found in {fn}, using the density from the first one')
@@ -415,7 +415,7 @@ class HubbardHamiltonian(object):
         """
         if not os.path.isfile(fn):
             mode = 'w'
-        fh = nc.ncSilehubbard(fn, mode=mode)
+        fh = nc.ncSileHubbard(fn, mode=mode)
         fh.write_density(self.n, self.U, self.kT, self.units, group)
 
     def write_initspin(self, fn, ext_geom=None, spinfix=True, mode='a', eps=0.1):

--- a/hubbard/hamiltonian.py
+++ b/hubbard/hamiltonian.py
@@ -36,12 +36,16 @@ class HubbardHamiltonian(object):
         Number of k-points along (a1, a2, a3) for Monkhorst-Pack BZ sampling
     kT: float, optional
         Temperature of the system in units of the Boltzmann constant
+    units: str, optional
+        (energy) units of U, kT and the TB Hamiltonian parameters (namely the hopping term and the onsite energies).
+        If one uses another units then it should be specified here. electron volts are used by default
     """
 
-    def __init__(self, TBHam, n=0, U=0.0, q=(0., 0.), nkpt=[1, 1, 1], kT=1e-5):
+    def __init__(self, TBHam, n=0, U=0.0, q=(0., 0.), nkpt=[1, 1, 1], kT=1e-5, units='eV'):
         """ Initialize HubbardHamiltonian """
 
         self.U = U # hubbard onsite Coulomb parameter
+        self.units = units # Label to know the used units
 
         # Copy TB Hamiltonian to store the converged one in a different variable
         self.TBHam = TBHam
@@ -117,7 +121,7 @@ class HubbardHamiltonian(object):
 
     def __str__(self):
         """ Representation of the model """
-        s = self.__class__.__name__ + f'{{q: {self.q}, U: {self.U}, kT: {self.kT}\n'
+        s = self.__class__.__name__ + f'{{q: {self.q}, U: {self.U} {self.units}, kT: {self.kT} {self.units}\n'
         s += str(self.H).replace('\n', '\n ')
         return s + '\n}'
 
@@ -412,7 +416,7 @@ class HubbardHamiltonian(object):
         if not os.path.isfile(fn):
             mode = 'w'
         fh = nc.ncSilehubbard(fn, mode=mode)
-        fh.write_density(self.n, self.U, self.kT, group)
+        fh.write_density(self.n, self.U, self.kT, self.units, group)
 
     def write_initspin(self, fn, ext_geom=None, spinfix=True, mode='a', eps=0.1):
         """ Write spin polarization to SIESTA fdf-block

--- a/hubbard/ncsile.py
+++ b/hubbard/ncsile.py
@@ -117,7 +117,7 @@ class ncSilehubbard(sisl.SileCDF):
                         n.append(_n)
         return n
 
-    def write_density(self, n, U, kT, group=None):
+    def write_density(self, n, U, kT, units, group=None):
         # Create group
         if group is not None:
             g = self._crt_grp(self, group)
@@ -133,8 +133,8 @@ class ncSilehubbard(sisl.SileCDF):
         v2 = self._crt_var(g, 'U', 'f8')
         v3 = self._crt_var(g, 'kT', 'f8')
         v1.info = 'Spin densities'
-        v2.info = 'Coulomb repulsion parameter'
-        v3.info = 'Temperature of the system'
+        v2.info = 'Coulomb repulsion parameter in ' + units
+        v3.info = 'Temperature of the system in '+ units
         g.variables['n'][:] = n
         g.variables['U'][:] = U
         g.variables['kT'][:] = kT

--- a/hubbard/ncsile.py
+++ b/hubbard/ncsile.py
@@ -1,6 +1,5 @@
 import numpy as np
 import sisl
-import warnings
 
 __all__ = ['ncSilehubbard']
 

--- a/hubbard/ncsile.py
+++ b/hubbard/ncsile.py
@@ -1,10 +1,10 @@
 import numpy as np
 import sisl
 
-__all__ = ['ncSilehubbard']
+__all__ = ['ncSileHubbard']
 
 
-class ncSilehubbard(sisl.SileCDF):
+class ncSileHubbard(sisl.SileCDF):
     """ Read and write `hubbard.HubbardHamiltonian` object in binary files (netCDF4 support)
 
     See Also
@@ -139,4 +139,4 @@ class ncSilehubbard(sisl.SileCDF):
         v2[:] = U
         v3[:] = kT
 
-sisl.io.add_sile("HU.nc", ncSilehubbard, gzip=False)
+sisl.io.add_sile("HU.nc", ncSileHubbard, gzip=False)

--- a/hubbard/ncsile.py
+++ b/hubbard/ncsile.py
@@ -138,3 +138,5 @@ class ncSilehubbard(sisl.SileCDF):
         g.variables['n'][:] = n
         g.variables['U'][:] = U
         g.variables['kT'][:] = kT
+
+sisl.io.add_sile("HU.nc", ncSilehubbard, gzip=False)

--- a/hubbard/ncsile.py
+++ b/hubbard/ncsile.py
@@ -34,7 +34,7 @@ class ncSilehubbard(sisl.SileCDF):
         else:
             # Try reading U saved without group
             try:
-                U = np.array(self.variables['n'][:])
+                U = np.array(self.variables['U'][:])
             except:
                 # Read from all groups, append all U
                 if self.groups:

--- a/hubbard/ncsile.py
+++ b/hubbard/ncsile.py
@@ -4,10 +4,6 @@ import sisl
 __all__ = ['ncSilehubbard']
 
 
-def get_sile(file, *args, **kwargs):
-    # returns a sile object
-    return ncSilehubbard(file, *args, **kwargs)
-
 class ncSilehubbard(sisl.SileCDF):
     """ Read and write `hubbard.HubbardHamiltonian` object in binary files (netCDF4 support)
 
@@ -34,17 +30,20 @@ class ncSilehubbard(sisl.SileCDF):
                 g = self.groups[group]
                 U = np.array(g.variables['U'][:])
             else:
-                raise ValueError(f'group {group} does not exist in file {file}')
+                raise ValueError(f'group {group} does not exist in file {self._file}')
         else:
-            if self.groups:
-                U = []
-                for k in self.groups:
-                    # Read Coulomb repulsion U parameter from all groups and append them in a list
-                    g = self.groups[k]
-                    _U = np.array(g.variables['U'][:])
-                    U.append(_U)
-            else:
-                U = np.array(self.variables['U'][:])
+            # Try reading U saved without group
+            try:
+                U = np.array(self.variables['n'][:])
+            except:
+                # Read from all groups, append all U
+                if self.groups:
+                    U  = []
+                    for k in self.groups:
+                        g = self.groups[k]
+                        # Read U from all groups and append them in a list
+                        _U = np.array(g.variables['U'][:])
+                        U.append(_U)
         return U
 
     def read_kT(self, group=None):
@@ -67,17 +66,20 @@ class ncSilehubbard(sisl.SileCDF):
                 # Read kT
                 kT = np.array(g.variables['kT'][:])
             else:
-                raise ValueError(f'group {group} does not exist in file {file}')
+                raise ValueError(f'group {group} does not exist in file {self._file}')
         else:
-            if self.groups:
-                kT = []
-                for k in self.groups:
-                    g = self.groups[k]
-                    # Read temperatures from all groups and append them in a list
-                    _kT = np.array(g.variables['kT'][:])
-                    kT.append(_kT)
-            else:
+            # Try reading kT saved without group
+            try:
                 kT = np.array(self.variables['kT'][:])
+            except:
+                # Read from all groups, append all kT
+                if self.groups:
+                    kT  = []
+                    for k in self.groups:
+                        g = self.groups[k]
+                        # Read kT from all groups and append them in a list
+                        _kT = np.array(g.variables['kT'][:])
+                        kT.append(_kT)
         return kT
 
     def read_density(self, group=None):
@@ -99,18 +101,20 @@ class ncSilehubbard(sisl.SileCDF):
                 g = self.groups[group]
                 n = np.array(g.variables['n'][:])
             else:
-                raise ValueError(f'group {group} does not exist in file {file}')
+                raise ValueError(f'group {group} does not exist in file {self._file}')
         else:
-            if self.groups:
-                n = []
-                for k in self.groups:
-                    g = self.groups[k]
-                    # Read densities from all groups and append them in a list
-                    _n = np.array(g.variables['n'][:])
-                    n.append(_n)
-            else:
-                # Read densities
+            # Try reading densities saved without group
+            try:
                 n = np.array(self.variables['n'][:])
+            except:
+                # Read from all groups, append all densities
+                if self.groups:
+                    n  = []
+                    for k in self.groups:
+                        g = self.groups[k]
+                        # Read densities from all groups and append them in a list
+                        _n = np.array(g.variables['n'][:])
+                        n.append(_n)
         return n
 
     def write_density(self, n, U, kT, group=None):

--- a/hubbard/ncsile.py
+++ b/hubbard/ncsile.py
@@ -17,61 +17,101 @@ class ncSilehubbard(sisl.SileCDF):
     sisl.io.SileCDF : sisl class
     """
     def read_U(self, group=None):
+        """
+        Read Coulomb repulsion U parameter from netcdf file
+
+        Parameters:
+        -----------
+        group: str, optional
+            netcdf group
+
+        Returns:
+        --------
+        Float or list of floats containing the temperature for each netcdf group
+        """
         # Find group
         if group is not None:
             if group in self.groups:
                 g = self.groups[group]
+                U = np.ma.getdata(g.variables['U'][:])
             else:
-                warnings.warn(f'group {group} does not exist in file {file}')
+                raise ValueError(f'group {group} does not exist in file {file}')
         else:
             if self.groups:
+                U = []
                 for k in self.groups:
-                    # If there are any groups read the density from the first one
+                    # Read Coulomb repulsion U parameter from all groups and append them in a list
                     g = self.groups[k]
-                    break
+                    _U = np.ma.getdata(g.variables['U'][:])
+                    U.append(_U)
             else:
-                g = self
-        # Read U
-        U = g.variables['U'][:]
+                U = np.ma.getdata(self.variables['U'][:])
         return U
 
     def read_kT(self, group=None):
+        """
+        Read temperature from netcdf file
+
+        Parameters:
+        -----------
+        group: str, optional
+            netcdf group
+
+        Returns:
+        --------
+        Float or list of floats containing the temperature times the Boltzmann constant (k) for each netcdf group
+        """
         # Find group
         if group is not None:
             if group in self.groups:
                 g = self.groups[group]
+                # Read kT
+                kT = np.ma.getdata(g.variables['kT'][:])
             else:
-                warnings.warn(f'group {group} does not exist in file {file}')
+                raise ValueError(f'group {group} does not exist in file {file}')
         else:
             if self.groups:
+                kT = []
                 for k in self.groups:
-                    # If there are any groups read the density from the first one
                     g = self.groups[k]
-                    break
+                    # Read temperatures from all groups and append them in a list
+                    _kT = np.ma.getdata(g.variables['kT'][:])
+                    kT.append(_kT)
             else:
-                g = self
-        # Read kT
-        kT = g.variables['kT'][:]
+                kT = np.ma.getdata(self.variables['kT'][:])
         return kT
 
     def read_density(self, group=None):
+        """
+        Read density from netcdf file
+
+        Parameters:
+        -----------
+        group: str, optional
+           netcdf group. If there are groups in the file and no group is found then it reads the n variable from all groups found
+
+        Return:
+        -------
+        numpy.ndarray or list of numpy.ndarrays
+        """
         # Find group
         if group is not None:
             if group in self.groups:
                 g = self.groups[group]
+                n = np.ma.getdata(g.variables['n'][:])
             else:
-                warnings.warn(f'group {group} does not exist in file {file}')
+                raise ValueError(f'group {group} does not exist in file {file}')
         else:
             if self.groups:
+                n = []
                 for k in self.groups:
-                    # If there are any groups read the density from the first one
                     g = self.groups[k]
-                    break
+                    # Read densities from all groups and append them in a list
+                    _n = np.ma.getdata(g.variables['n'][:])
+                    n.append(_n)
             else:
-                g = self
-
-        # Read densities
-        n = g.variables['n'][:]
+                # Read densities
+                n = np.ma.getdata(self.variables['n'][:])
         return n
 
     def write_density(self, n, U, kT, group=None):

--- a/hubbard/ncsile.py
+++ b/hubbard/ncsile.py
@@ -125,10 +125,12 @@ class ncSilehubbard(sisl.SileCDF):
         self._crt_dim(self, 'norb', n.shape[1])
 
         # Write variable n
-        v = self._crt_var(g, 'n', ('f8', 'f8'), ('nspin', 'norb'))
-        v = self._crt_var(g, 'U', 'f8')
-        v = self._crt_var(g, 'kT', 'f8')
-        v.info = 'Mean Field Hubbard calculation'
+        v1 = self._crt_var(g, 'n', ('f8', 'f8'), ('nspin', 'norb'))
+        v2 = self._crt_var(g, 'U', 'f8')
+        v3 = self._crt_var(g, 'kT', 'f8')
+        v1.info = 'Spin densities'
+        v2.info = 'Coulomb repulsion parameter'
+        v3.info = 'Temperature of the system'
         g.variables['n'][:] = n
         g.variables['U'][:] = U
         g.variables['kT'][:] = kT

--- a/hubbard/ncsile.py
+++ b/hubbard/ncsile.py
@@ -1,8 +1,13 @@
 import numpy as np
 import sisl
+import warnings
 
 __all__ = ['ncSilehubbard']
 
+
+def get_sile(file, *args, **kwargs):
+    # returns a sile object
+    return ncSilehubbard(file, *args, **kwargs)
 
 class ncSilehubbard(sisl.SileCDF):
     """ Read and write `hubbard.HubbardHamiltonian` object in binary files (netCDF4 support)
@@ -11,19 +16,70 @@ class ncSilehubbard(sisl.SileCDF):
     ------------
     sisl.io.SileCDF : sisl class
     """
-
-    def read_density(self, group):
+    def read_U(self, group=None):
         # Find group
-        g = self.groups[group]
+        if group is not None:
+            if group in self.groups:
+                g = self.groups[group]
+            else:
+                warnings.warn(f'group {group} does not exist in file {file}')
+        else:
+            if self.groups:
+                for k in self.groups:
+                    # If there are any groups read the density from the first one
+                    g = self.groups[k]
+                    break
+            else:
+                g = self
+        # Read U
+        U = g.variables['U'][:]
+        return U
+
+    def read_kT(self, group=None):
+        # Find group
+        if group is not None:
+            if group in self.groups:
+                g = self.groups[group]
+            else:
+                warnings.warn(f'group {group} does not exist in file {file}')
+        else:
+            if self.groups:
+                for k in self.groups:
+                    # If there are any groups read the density from the first one
+                    g = self.groups[k]
+                    break
+            else:
+                g = self
+        # Read kT
+        kT = g.variables['kT'][:]
+        return kT
+
+    def read_density(self, group=None):
+        # Find group
+        if group is not None:
+            if group in self.groups:
+                g = self.groups[group]
+            else:
+                warnings.warn(f'group {group} does not exist in file {file}')
+        else:
+            if self.groups:
+                for k in self.groups:
+                    # If there are any groups read the density from the first one
+                    g = self.groups[k]
+                    break
+            else:
+                g = self
 
         # Read densities
         n = g.variables['n'][:]
         return n
 
-    def write_density(self, infolabel, group, n):
+    def write_density(self, n, U, kT, group=None):
         # Create group
-        g = self._crt_grp(self, group)
-        g.info = infolabel
+        if group is not None:
+            g = self._crt_grp(self, group)
+        else:
+            g = self
 
         # Create dimensions
         self._crt_dim(self, 'ncomp', n.shape[0])
@@ -31,5 +87,9 @@ class ncSilehubbard(sisl.SileCDF):
 
         # Write variable n
         v = self._crt_var(g, 'n', ('f8', 'f8'), ('ncomp', 'norb'))
+        v = self._crt_var(g, 'U', 'f8')
+        v = self._crt_var(g, 'kT', 'f8')
         v.info = 'Densities'
         g.variables['n'][:] = n
+        g.variables['U'][:] = U
+        g.variables['kT'][:] = kT

--- a/hubbard/ncsile.py
+++ b/hubbard/ncsile.py
@@ -135,8 +135,8 @@ class ncSilehubbard(sisl.SileCDF):
         v1.info = 'Spin densities'
         v2.info = 'Coulomb repulsion parameter in ' + units
         v3.info = 'Temperature of the system in '+ units
-        g.variables['n'][:] = n
-        g.variables['U'][:] = U
-        g.variables['kT'][:] = kT
+        v1[:] = n
+        v2[:] = U
+        v3[:] = kT
 
 sisl.io.add_sile("HU.nc", ncSilehubbard, gzip=False)

--- a/hubbard/ncsile.py
+++ b/hubbard/ncsile.py
@@ -32,7 +32,7 @@ class ncSilehubbard(sisl.SileCDF):
         if group is not None:
             if group in self.groups:
                 g = self.groups[group]
-                U = np.ma.getdata(g.variables['U'][:])
+                U = np.array(g.variables['U'][:])
             else:
                 raise ValueError(f'group {group} does not exist in file {file}')
         else:
@@ -41,10 +41,10 @@ class ncSilehubbard(sisl.SileCDF):
                 for k in self.groups:
                     # Read Coulomb repulsion U parameter from all groups and append them in a list
                     g = self.groups[k]
-                    _U = np.ma.getdata(g.variables['U'][:])
+                    _U = np.array(g.variables['U'][:])
                     U.append(_U)
             else:
-                U = np.ma.getdata(self.variables['U'][:])
+                U = np.array(self.variables['U'][:])
         return U
 
     def read_kT(self, group=None):
@@ -65,7 +65,7 @@ class ncSilehubbard(sisl.SileCDF):
             if group in self.groups:
                 g = self.groups[group]
                 # Read kT
-                kT = np.ma.getdata(g.variables['kT'][:])
+                kT = np.array(g.variables['kT'][:])
             else:
                 raise ValueError(f'group {group} does not exist in file {file}')
         else:
@@ -74,10 +74,10 @@ class ncSilehubbard(sisl.SileCDF):
                 for k in self.groups:
                     g = self.groups[k]
                     # Read temperatures from all groups and append them in a list
-                    _kT = np.ma.getdata(g.variables['kT'][:])
+                    _kT = np.array(g.variables['kT'][:])
                     kT.append(_kT)
             else:
-                kT = np.ma.getdata(self.variables['kT'][:])
+                kT = np.array(self.variables['kT'][:])
         return kT
 
     def read_density(self, group=None):
@@ -97,7 +97,7 @@ class ncSilehubbard(sisl.SileCDF):
         if group is not None:
             if group in self.groups:
                 g = self.groups[group]
-                n = np.ma.getdata(g.variables['n'][:])
+                n = np.array(g.variables['n'][:])
             else:
                 raise ValueError(f'group {group} does not exist in file {file}')
         else:
@@ -106,11 +106,11 @@ class ncSilehubbard(sisl.SileCDF):
                 for k in self.groups:
                     g = self.groups[k]
                     # Read densities from all groups and append them in a list
-                    _n = np.ma.getdata(g.variables['n'][:])
+                    _n = np.array(g.variables['n'][:])
                     n.append(_n)
             else:
                 # Read densities
-                n = np.ma.getdata(self.variables['n'][:])
+                n = np.array(self.variables['n'][:])
         return n
 
     def write_density(self, n, U, kT, group=None):
@@ -121,14 +121,14 @@ class ncSilehubbard(sisl.SileCDF):
             g = self
 
         # Create dimensions
-        self._crt_dim(self, 'ncomp', n.shape[0])
+        self._crt_dim(self, 'nspin', n.shape[0])
         self._crt_dim(self, 'norb', n.shape[1])
 
         # Write variable n
-        v = self._crt_var(g, 'n', ('f8', 'f8'), ('ncomp', 'norb'))
+        v = self._crt_var(g, 'n', ('f8', 'f8'), ('nspin', 'norb'))
         v = self._crt_var(g, 'U', 'f8')
         v = self._crt_var(g, 'kT', 'f8')
-        v.info = 'Densities'
+        v.info = 'Mean Field Hubbard calculation'
         g.variables['n'][:] = n
         g.variables['U'][:] = U
         g.variables['kT'][:] = kT

--- a/tests/test-hubbard-io.py
+++ b/tests/test-hubbard-io.py
@@ -24,14 +24,14 @@ H.n *= 2
 H.write_density('mol-ref/test.HU.nc', group='group2', mode='a')
 
 
-print('3. Read density, U and kT using ncsile')
-# Since there are two groups in the file at this point and none is specified it reads everything
+print('3. Read density, U and kT using ncsile from all groups')
 fh = sisl.get_sile('mol-ref/test.HU.nc', mode='r')
-print('n: ', fh.read_density(group=None))
-print('U: ', fh.read_U(group=None))
-print('kT: ', fh.read_kT(group=None))
-
-print('\n')
+for g in fh.groups:
+    print('group: ', g)
+    print('n:', fh.read_density(group=g))
+    print('U:', fh.read_U(group=g))
+    print('kT:', fh.read_kT(group=g))
+    print('\n')
 
 print('4. Read using HubbardHamiltoninan class')
 # Read density using the HubbardHamiltonian class

--- a/tests/test-hubbard-io.py
+++ b/tests/test-hubbard-io.py
@@ -1,0 +1,60 @@
+from hubbard import HubbardHamiltonian, sp2, ncsile
+import sisl
+import numpy as np
+
+# Build sisl Geometry object only for a subset of atoms
+molecule = sisl.get_sile('mol-ref/mol-ref.XV').read_geometry().sub([2,3,5])
+molecule.sc.set_nsc([1, 1, 1])
+
+# Build HubbardHamiltonian object
+Hsp2 = sp2(molecule)
+H = HubbardHamiltonian(Hsp2, U=3.5)
+# Generate simple density
+H.n = np.ones((2, H.sites))*0.5
+
+print(f'1. Write and read densities under group {H.get_hash()} using the HubbardHamiltonian class\n')
+# Write density in file
+H.write_density('mol-ref/test.nc', group=H.get_hash(), mode='w')
+# Read density using the HubbardHamiltonian class
+H.read_density('mol-ref/test.nc', group=H.get_hash())
+
+# Write another density in file under another group
+print(f'2. Write another densities under another group\n')
+H.n *= 2
+H.write_density('mol-ref/test.nc', group='group2', mode='a')
+
+
+print('3. Read density, U and kT using ncsile')
+# Since there are two groups in the file at this point and no one is specified it reads everything
+fh = ncsile.ncSilehubbard('mol-ref/test.nc', mode='r')
+print('n: ', fh.read_density(group=None))
+print('U: ', fh.read_U(group=None))
+print('kT: ', fh.read_kT(group=None))
+
+print('\n')
+
+print('4. Read using HubbardHamiltoninan class')
+# Read density using the HubbardHamiltonian class
+H.read_density('mol-ref/test.nc', group=None)
+print('H.n:', H.n)
+
+print('\n')
+
+# Write another density in file under no group
+print(f'5. Write and read another densities without group using the HubbardHamiltonian class\n')
+H.n *= 4
+H.write_density('mol-ref/test.nc', group=None, mode='a')
+# Read density using the HubbardHamiltonian class
+H.read_density('mol-ref/test.nc', group=None)
+print('H.n:', H.n)
+
+
+'''
+# These lines don't work for some reason when the file is in another folder,
+# but when the folder path is the same as this script then it works....
+# Add sile and use sisl to read density, U and kT
+sisl.io.add_sile('mol-ref/test.nc', hubbard.ncsile.ncSilehubbard, gzip=False)
+print('n: ', sisl.get_sile('mol-ref/test.nc').read_density(group='random'))
+print('U: ',sisl.get_sile('mol-ref/test.nc').read_U(group='random'))
+print('kT: ',sisl.get_sile('mol-ref/test.nc').read_kT(group='random'))
+'''

--- a/tests/test-hubbard-io.py
+++ b/tests/test-hubbard-io.py
@@ -14,19 +14,19 @@ H.n = np.ones((2, H.sites))*0.5
 
 print(f'1. Write and read densities under group {H.get_hash()} using the HubbardHamiltonian class\n')
 # Write density in file
-H.write_density('mol-ref/test.nc', group=H.get_hash(), mode='w')
+H.write_density('mol-ref/test.HU.nc', group=H.get_hash(), mode='w')
 # Read density using the HubbardHamiltonian class
-H.read_density('mol-ref/test.nc', group=H.get_hash())
+H.read_density('mol-ref/test.HU.nc', group=H.get_hash())
 
 # Write another density in file under another group
 print(f'2. Write another densities under another group\n')
 H.n *= 2
-H.write_density('mol-ref/test.nc', group='group2', mode='a')
+H.write_density('mol-ref/test.HU.nc', group='group2', mode='a')
 
 
 print('3. Read density, U and kT using ncsile')
-# Since there are two groups in the file at this point and no one is specified it reads everything
-fh = ncsile.ncSilehubbard('mol-ref/test.nc', mode='r')
+# Since there are two groups in the file at this point and none is specified it reads everything
+fh = sisl.get_sile('mol-ref/test.HU.nc', mode='r')
 print('n: ', fh.read_density(group=None))
 print('U: ', fh.read_U(group=None))
 print('kT: ', fh.read_kT(group=None))
@@ -35,7 +35,7 @@ print('\n')
 
 print('4. Read using HubbardHamiltoninan class')
 # Read density using the HubbardHamiltonian class
-H.read_density('mol-ref/test.nc', group=None)
+H.read_density('mol-ref/test.HU.nc', group=None)
 print('H.n:', H.n)
 
 print('\n')
@@ -43,18 +43,7 @@ print('\n')
 # Write another density in file under no group
 print(f'5. Write and read another densities without group using the HubbardHamiltonian class\n')
 H.n *= 4
-H.write_density('mol-ref/test.nc', group=None, mode='a')
+H.write_density('mol-ref/test.HU.nc', group=None, mode='a')
 # Read density using the HubbardHamiltonian class
-H.read_density('mol-ref/test.nc', group=None)
+H.read_density('mol-ref/test.HU.nc', group=None)
 print('H.n:', H.n)
-
-
-'''
-# These lines don't work for some reason when the file is in another folder,
-# but when the folder path is the same as this script then it works....
-# Add sile and use sisl to read density, U and kT
-sisl.io.add_sile('mol-ref/test.nc', hubbard.ncsile.ncSilehubbard, gzip=False)
-print('n: ', sisl.get_sile('mol-ref/test.nc').read_density(group='random'))
-print('U: ',sisl.get_sile('mol-ref/test.nc').read_U(group='random'))
-print('kT: ',sisl.get_sile('mol-ref/test.nc').read_kT(group='random'))
-'''

--- a/tests/test-hubbard-quick.py
+++ b/tests/test-hubbard-quick.py
@@ -1,5 +1,4 @@
 from hubbard import HubbardHamiltonian, sp2, density, NEGF
-import numpy as np
 import sisl
 
 # Build sisl Geometry object
@@ -14,7 +13,7 @@ dn = H.iterate(density.calc_n_insulator, mixer=sisl.mixing.LinearMixer())
 print('   dn, Etot: ', dn, H.Etot, '\n')
 
 print('2. Run one iteration with data from ncfile')
-H.read_density('mol-ref/density.nc')
+H.read_density('mol-ref/density.nc', group='3abe772')
 dn = H.iterate(density.calc_n_insulator, mixer=sisl.mixing.LinearMixer())
 etot = 1 * H.Etot
 print('   dn, Etot: ', dn, etot, '\n')


### PR DESCRIPTION
I find it a little inconvenient that the current `read_density` function only reads the density if there is matching hash. With this PR I now allow for reading the density from `netCDF` files even in cases where the hash doesn't match.