### PR TITLE
Generalize `HubbardHamiltonian` class to have intra- and inter-atomic interactions

### DIFF
--- a/examples/molecules/kondo-paper/fig_S11-S13.py
+++ b/examples/molecules/kondo-paper/fig_S11-S13.py
@@ -18,7 +18,7 @@ mixer = sisl.mixing.PulayMixer(0.7, history=12)
 
 for u in [0.0, 3.5]:
     H.U = u
-    if H.U == 0:
+    if np.allclose(H.U, 0):
         lab = 'Fig_S12'
     else:
         lab = 'Fig_S13'
@@ -31,8 +31,8 @@ for u in [0.0, 3.5]:
 
     # Plot Eigenspectrum
     p = plot.Spectrum(H, ymax=0.12)
-    p.set_title(r'3NN, $U=%.2f$ eV'%H.U)
-    p.savefig('Fig_S11_eigenspectrum_U%i.pdf'%(H.U*100))
+    p.set_title(r'3NN, $U=%.2f$ eV'%np.average(H.U))
+    p.savefig('Fig_S11_eigenspectrum_U%i.pdf'%(np.average(H.U)*100))
 
     # Plot HOMO and LUMO level wavefunctions for up- and down-electrons
     spin = ['up', 'dn']

--- a/hubbard/hamiltonian.py
+++ b/hubbard/hamiltonian.py
@@ -1,7 +1,6 @@
 import numpy as np
 import sisl
 import hubbard.ncsile as nc
-import hashlib
 import os
 import math
 import warnings
@@ -78,11 +77,8 @@ class HubbardHamiltonian(object):
             except AttributeError:
                 U = 0.0
 
-        # Hubbard Coulomb parameter
-        self.U = U*np.identity(len(self.geometry)) # Multiply with the identity matrix to ensure that the U variable is a matrix
-        # Separate into intra and inter-atomic interactions:
-        self.U_ii = np.diag(self.U)
-        self.U_ij = self.U - self.U_ii*np.identity(len(self.geometry))
+        # Hubbard Coulomb parameter (use setter)
+        self.U = U
 
         # Total initial charge
         ntot = self.geometry.q0
@@ -122,6 +118,22 @@ class HubbardHamiltonian(object):
                 self.n = n
         # Ensure normalized charge
         self.normalize_charge()
+
+    @property
+    def U(self):
+        """ U values in full matrix form """
+        return self._U
+
+    @U.setter
+    def U(self, U):
+        """ Set U values """
+        # Hubbard Coulomb parameter
+        # Multiply with the identity matrix to ensure that the U variable is a matrix
+        self._U = U * np.identity(len(self.geometry))
+        # Separate into intra and inter-atomic interactions:
+        self._U_ii = np.diag(self._U)
+        self._U_ij = self._U.copy()
+        np.fill_diagonal(self._U_ij, 0.)
 
     def set_kmesh(self, nkpt=[1, 1, 1]):
         """ Set the k-mesh for the HubbardHamiltonian

--- a/hubbard/hamiltonian.py
+++ b/hubbard/hamiltonian.py
@@ -26,8 +26,8 @@ class HubbardHamiltonian(object):
         An unpolarized or spin-polarized tight-binding Hamiltonian
     n: numpy.ndarray, optional
         initial spin-densities vectors. The shape of `n` must be (spin deg. of freedom, no. of sites)
-    U: float, optional
-        on-site Coulomb repulsion
+    U: float or np.ndarray, optional
+        Coulomb repulsion parameter
     q: array_like, optional
         One or two values specifying the total charge associated to each spin component.
         The array should contain as many values as the dimension of the problem. I.e., if the
@@ -39,6 +39,10 @@ class HubbardHamiltonian(object):
     units: str, optional
         (energy) units of U, kT and the TB Hamiltonian parameters (namely the hopping term and the onsite energies).
         If one uses another units then it should be specified here. electron volts are used by default
+
+    Note
+    ----
+    The implementation to solve the extended Hubbard model (with inter-atomic interactions) has not been tested
     """
 
     def __init__(self, TBHam, n=0, U=0.0, q=(0., 0.), nkpt=[1, 1, 1], kT=1e-5, units='eV'):

--- a/hubbard/hamiltonian.py
+++ b/hubbard/hamiltonian.py
@@ -65,12 +65,12 @@ class HubbardHamiltonian(object):
         self._hash_base = s
         del H0
 
-        if U == None:
+        if U is None:
             try:
                 # Try to extract U stored in sisl.Geometry object
                 U = np.array(len(self.geometry))
                 for ia in self.geometry:
-                    U[ia] = self.geometry.atom[ia].U
+                    U[ia] = self.geometry.atoms[ia].U
             except AttributeError:
                 U = 0.0
 
@@ -293,7 +293,7 @@ class HubbardHamiltonian(object):
         ispin = np.arange(self.spin_size)[::-1]
         # diagonal elements
         E += self.U_ii * (self.n[ispin, :] - q0)
-        # off-diafonal elements
+        # off-diagonal elements
         E += 0.5*(self.U_ij+self.U_ij.T) @ ((self.n[0]+self.n[-1]) - q0) # Same thing adds to both spin components
         a = np.arange(len(self.H))
         self.H[a, a, range(self.spin_size)] = E.T

--- a/hubbard/hamiltonian.py
+++ b/hubbard/hamiltonian.py
@@ -1,6 +1,7 @@
 import numpy as np
 import sisl
 import hubbard.ncsile as nc
+import hashlib
 import os
 import math
 import warnings

--- a/hubbard/hamiltonian.py
+++ b/hubbard/hamiltonian.py
@@ -58,6 +58,12 @@ class HubbardHamiltonian(object):
         # So far we only consider either unpolarized or spin-polarized Hamiltonians
         self.spin_size = self.H.spin.spinor
 
+        # Check that there is only one obrital per atom (at least for the moment)
+        try:
+            assert self.geometry.na == self.geometry.no
+        except AssertionError:
+            raise ValueError('The number of orbitals has to be equal to the number of atoms in the geometry')
+
         # Use sum of all matrix elements as a basis for hash function calls
         H0 = self.TBHam.copy()
         H0.shift(np.pi) # Apply a shift to incorporate effect of S

--- a/hubbard/hamiltonian.py
+++ b/hubbard/hamiltonian.py
@@ -48,7 +48,6 @@ class HubbardHamiltonian(object):
     def __init__(self, TBHam, n=0, U=0.0, q=(0., 0.), nkpt=[1, 1, 1], kT=1e-5, units='eV'):
         """ Initialize HubbardHamiltonian """
 
-        self.U = U # hubbard onsite Coulomb parameter
         self.units = units # Label to know the used units
 
         # Copy TB Hamiltonian to store the converged one in a different variable
@@ -309,9 +308,9 @@ class HubbardHamiltonian(object):
         E = self.e0.copy()
         ispin = np.arange(self.spin_size)[::-1]
         # diagonal elements
-        E += self.U_ii * (self.n[ispin, :] - q0)
+        E += self._U_ii * (self.n[ispin, :] - q0)
         # off-diagonal elements
-        E += 0.5*(self.U_ij+self.U_ij.T) @ ((self.n[0]+self.n[-1]) - q0) # Same thing adds to both spin components
+        E += 0.5*(self._U_ij+self._U_ij.T) @ ((self.n[0]+self.n[-1]) - q0) # Same thing adds to both spin components
         a = np.arange(len(self.H))
         self.H[a, a, range(self.spin_size)] = E.T
 
@@ -551,7 +550,7 @@ class HubbardHamiltonian(object):
         self.update_hamiltonian()
 
         # Store total energy
-        self.Etot = Etot - (self.U_ii * ni[0]*ni[-1]).sum() - 0.5*self.U_ij @ (ni[0]+ni[-1]) @ (ni[0]+ni[-1])
+        self.Etot = Etot - (self._U_ii * ni[0]*ni[-1]).sum() - 0.5*self._U_ij @ (ni[0]+ni[-1]) @ (ni[0]+ni[-1])
         return dn
 
     def converge(self, calc_n_method, tol=1e-6, mixer=None, steps=100, fn=None, print_info=False, func_args=dict()):

--- a/hubbard/hamiltonian.py
+++ b/hubbard/hamiltonian.py
@@ -320,7 +320,7 @@ class HubbardHamiltonian(object):
         E += self.U * (self.n[ispin, :] - self.q0)
         # off-diagonal elements
         if self.Uij is not None:
-            E += 0.5*(self.Uij+self.Uij.T) @ ((self.n[0]+self.n[-1]) - self.q0) # Same thing adds to both spin components
+            E += self.Uij @ ((self.n[0]+self.n[-1]) - self.q0) # Same thing adds to both spin components
         a = np.arange(len(self.H))
         self.H[a, a, range(self.spin_size)] = E.T
 

--- a/hubbard/hamiltonian.py
+++ b/hubbard/hamiltonian.py
@@ -59,6 +59,7 @@ class HubbardHamiltonian(object):
         self.geometry = TBHam.geometry
         # So far we only consider either unpolarized or spin-polarized Hamiltonians
         self.spin_size = self.H.spin.spinor
+        self.sites = self.geometry.no
 
         # Use sum of all matrix elements as a basis for hash function calls
         H0 = self.TBHam.copy()
@@ -73,9 +74,9 @@ class HubbardHamiltonian(object):
         if U is None:
             try:
                 # Try to extract U stored in sisl.Geometry object (intra-orbital Coulomb repulsion)
-                U = np.array(len(self.geometry))
-                for ia in self.geometry:
-                    U[ia] = self.geometry.atoms[ia].U
+                U = np.empty(self.sites)
+                for ia,io in self.geometry.iter_orbitals():
+                    U[ia] = self.geometry.atoms[ia].orbitals[io].U
             except AttributeError:
                 U = 0.0
 
@@ -86,7 +87,6 @@ class HubbardHamiltonian(object):
 
         # Total initial charge
         ntot = self.geometry.q0
-        self.sites = self.geometry.no
 
         if ntot == 0:
             ntot = self.geometry.na

--- a/hubbard/hamiltonian.py
+++ b/hubbard/hamiltonian.py
@@ -103,7 +103,7 @@ class HubbardHamiltonian(object):
             else:
                 self.q[0] = ntot / 2
 
-        self.q0 = np.zeros((self.sites))
+        self.q0 = np.zeros(self.sites)
         for atom, a_idx in self.geometry.atoms.iter(True):
             for ia in a_idx:
                 io =  self.geometry.a2o(ia, all=True)
@@ -304,14 +304,20 @@ class HubbardHamiltonian(object):
     def update_hamiltonian(self):
         r""" Update spin Hamiltonian according to the extended Hubbard model,
         see for instance `PRL 106, 236805 (2011)<https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.106.236805>`_
-        It updtates the diagonal elements for each spin Hamiltonian following the mean field approximation:
+        It updates the diagonal elements for each spin Hamiltonian following the mean field approximation:
 
         .. math::
 
-            H &= -\sum_{ij\sigma}t_{ij\sigma}c^{\dagger}_{i\sigma}c_{j\sigma} + \sum_{i}U_in_{i\uparrow}n_{i\downarrow} + \frac{1}{2}\sum_{i\neq j\sigma\sigma^\prime}U_{ij}n_{i\sigma}n_{j\sigma^\prime} \approx\\
-	        & -\sum_{ij\sigma}t_{ij\sigma}c^{\dagger}_{i\sigma}c_{j\sigma} + \sum_{i\sigma} U_i \left\langle n_{i\sigma}\right\rangle n_{i\bar{\sigma}} + \frac{1}{2}\sum_{i\neq j\sigma}\left(U_{ij} + U_{ji}\right)\left(\langle n_{i\uparrow}\rangle + \langle n_{i\downarrow}\rangle\right)n_{j\sigma} + C
+            H &= -\sum_{ij\sigma}t_{ij\sigma}c^{\dagger}_{i\sigma}c_{j\sigma} + \sum_{i}U_in_{i\uparrow}n_{i\downarrow} +
+            \frac{1}{2}\sum_{i\neq j\sigma\sigma^\prime}U_{ij}n_{i\sigma}n_{j\sigma^\prime} \approx\\
+	        & -\sum_{ij\sigma}t_{ij\sigma}c^{\dagger}_{i\sigma}c_{j\sigma} +
+            \sum_{i\sigma} U_i \left\langle n_{i\sigma}\right\rangle n_{i\bar{\sigma}} +
+            \frac{1}{2}\sum_{i\neq j\sigma}\left(U_{ij}
+            + U_{ji}\right)\left(\langle n_{i\uparrow}\rangle + \langle n_{i\downarrow}\rangle\right)n_{j\sigma} + C
 
-        The constat term :math:`C = -\sum_i U_i \langle n_{i\uparrow}\rangle\langle n_{i\downarrow}\rangle - \frac{1}{2}\sum_{i\neq j}U_{ij}\left(\langle n_{i\uparrow}\rangle+\langle n_{i\downarrow}\rangle\right)\left(\langle n_{j\uparrow}\rangle + \langle n_{j\downarrow}\rangle\right)`
+        The constant term :math:`C = -\sum_i U_i \langle n_{i\uparrow}\rangle\langle n_{i\downarrow}\rangle -
+        \frac{1}{2}\sum_{i\neq j}U_{ij}\left(\langle n_{i\uparrow}\rangle+\langle n_{i\downarrow}\rangle\right)\left(\langle n_{j\uparrow}\rangle
+        + \langle n_{j\downarrow}\rangle\right)`
         will be added to the Hamiltonian in the `iterate` method, where the total energy is calculated
         """
         E = self.e0.copy()

--- a/hubbard/ncsile.py
+++ b/hubbard/ncsile.py
@@ -130,7 +130,7 @@ class ncSileHubbard(sisl.SileCDF):
 
         # Write variable n
         v1 = self._crt_var(g, 'n', ('f8', 'f8'), ('nspin', 'norb'))
-        v2 = self._crt_var(g, 'U', 'f8')
+        v2 = self._crt_var(g, 'U', ('f8', 'f8'), ('norb', 'norb'))
         v3 = self._crt_var(g, 'kT', 'f8')
         v1.info = 'Spin densities'
         v2.info = 'Coulomb repulsion parameter in ' + units

--- a/tests/test-hubbard-multi-orbitals.py
+++ b/tests/test-hubbard-multi-orbitals.py
@@ -1,0 +1,67 @@
+from sisl import geom, Atom
+import os
+from add_Hatoms import *
+from hubbard import HubbardHamiltonian, sp2, density, plot
+
+W = 7
+bond = 1.42
+
+# single-orbital
+g = geom.zgnr(W)
+TBHam = sp2(g, t1=2.7, t2=0, t3=0)
+HH = HubbardHamiltonian(TBHam, U=3, nkpt=[100,1,1])
+#print(HH.geometry.atoms.atom[0].q0)
+HH.set_polarization([0], dn=[-1])
+HH.converge(density.calc_n, print_info=True, tol=1e-10, steps=3)
+n_single = HH.n*1
+
+# Start bands-plot, the single-orbital case will be plotted in black
+p = plot.Bandstructure(HH, c='k')
+
+# Multi-orbital tight-binding Hamiltonian
+pz = sisl.Orbital(1.42, q0=1.0)
+s = sisl.Orbital(1.42, q0=0)
+C = sisl.Atom(6, orbitals=[pz, s])
+g = geom.zgnr(W, atoms=C)
+
+# Add another atom to have also "heteroatom" situation
+B = sisl.Atom(6, orbitals=[pz])
+G_B = sisl.Geometry(g.xyz[0], atoms=B)
+g = g.replace(0,G_B)
+
+# Identify index for atoms
+idx = g.a2o(range(len(g)))
+
+# Build U for each orbital in each atom
+U = np.zeros(g.no)
+U[idx] = 3.
+
+# Build TB Hamiltonian, zeroes for non-pz orbitals
+TBham = sisl.Hamiltonian(g, spin='polarized')
+for ia in g:
+    ib = g.close(ia, R=[0,1.42+0.1])
+    io_a = g.a2o(ia, all=True)
+    for iib in ib[1]:
+        io_b = g.a2o(iib, all=True)
+        TBham[io_a[0], io_b[0]] = -2.7
+
+# HubbardHamiltonian object and converge
+HH = HubbardHamiltonian(TBham, U=U, nkpt=[100,1,1])
+HH.set_polarization([0], dn=[g.a2o(13)])
+HH.converge(density.calc_n, print_info=True, tol=1e-10, steps=3)
+
+# Print spin-densities difference compared to sing-orbital case
+print('\n   ** Difference between spin densities for single and multi-orbital cases **')
+print(HH.n[:,idx]-n_single)
+
+# Add second set of bands for the multi orbital case
+p.add_bands(HH, c='--r')
+p.savefig('bands.pdf')
+
+# Plot charge for multi-orbital case
+p = plot.Charge(HH)
+p.savefig('charge.pdf')
+
+# Plot spin polarization for multi-orbital case
+p = plot.SpinPolarization(HH, vmax=0.2, vmin=-0.2)
+p.savefig('spinpol.pdf')

--- a/tests/test-hubbard-multi-orbitals.py
+++ b/tests/test-hubbard-multi-orbitals.py
@@ -1,6 +1,7 @@
+import sisl
 from sisl import geom, Atom
+import numpy as np
 import os
-from add_Hatoms import *
 from hubbard import HubbardHamiltonian, sp2, density, plot
 
 W = 7
@@ -24,10 +25,10 @@ s = sisl.Orbital(1.42, q0=0)
 C = sisl.Atom(6, orbitals=[pz, s])
 g = geom.zgnr(W, atoms=C)
 
-# Add another atom to have also "heteroatom" situation
-B = sisl.Atom(6, orbitals=[pz])
-G_B = sisl.Geometry(g.xyz[0], atoms=B)
-g = g.replace(0,G_B)
+# Add another atom to have heterogeneous number of orbitals per atoms
+C2 = sisl.Atom(6, orbitals=[pz])
+G_C2 = sisl.Geometry(g.xyz[0], atoms=C2)
+g = g.replace(0,G_C2)
 
 # Identify index for atoms
 idx = g.a2o(range(len(g)))
@@ -59,9 +60,9 @@ p.add_bands(HH, c='--r')
 p.savefig('bands.pdf')
 
 # Plot charge for multi-orbital case
-p = plot.Charge(HH)
+p = plot.Charge(HH, vmin=0.9, vmax=1.1, colorbar=True)
 p.savefig('charge.pdf')
 
 # Plot spin polarization for multi-orbital case
-p = plot.SpinPolarization(HH, vmax=0.2, vmin=-0.2)
+p = plot.SpinPolarization(HH, vmax=0.2, vmin=-0.2, colorbar=True)
 p.savefig('spinpol.pdf')


### PR DESCRIPTION
With this implementation now one can pass a `U` that can be either a `float` or a `numpy.ndarray` with the possibility to have inter-atomic interactions also. This branch comes from PR  #82 since in order to test the `HubbardHamiltonian` class using the `test` scripts we need to read the density stored in the `mol-ref/mol-ref.nc` file, but since the hash doesn't match given the new implementation it can't extract the density and the tests fail.