### PR TITLE
Generalized LDOS plots

### DIFF
--- a/hubbard/plot/spectrum.py
+++ b/hubbard/plot/spectrum.py
@@ -113,9 +113,6 @@ class LDOSmap(Plot):
         unitvec = np.array(direction)
         unitvec = unitvec / unitvec.dot(unitvec) ** 0.5
         coord = xyz.dot(unitvec)
-        # distance perpendicular to projection axis
-        perp = xyz - coord.reshape(-1, 1) * unitvec
-        perp = np.einsum('ij,ij->i', perp, perp) ** 0.5
 
         xmin, xmax = min(coord) - dx, max(coord) + dx
         emin, emax = -emax, emax
@@ -125,7 +122,10 @@ class LDOSmap(Plot):
         dist_x = sisl.get_distribution(dist_x, smearing=gamma_x)
         xcoord = x.reshape(-1, 1) - coord.reshape(1, -1) # (nx, natoms)
         if projection.upper() == '1D':
-            xcoord = (xcoord ** 2 + perp ** 2) ** 0.5
+            # distance perpendicular to projection axis
+            perp = xyz - coord.reshape(-1, 1) * unitvec
+            perp = np.einsum('ij,ij->i', perp, perp)
+            xcoord = (xcoord ** 2 + perp) ** 0.5
         DX = dist_x(xcoord)
 
         # Broaden along energy axis


### PR DESCRIPTION
LDOS plot method is generalized to allow for projections in 1D and 2D along arbitrary directions.

For example, one can now do
```python
import hubbard.plot as plot

H = HubbardHamiltonian(...)

d = [1, 1, 0] # real-space direction 
o = H.H.geom.xyz[0] # coordinate of first atom in the geometry

p1d = plot.LDOSmap(H, direction=d, origo=o, projection='1d')
p2d = plot.LDOSmap(H, direction=d, origo=o, projection='2d')
```