### PR TITLE
Default q-values for spin-polarized calculations with odd number of electrons

### DIFF
--- a/hubbard/hamiltonian.py
+++ b/hubbard/hamiltonian.py
@@ -69,7 +69,7 @@ class HubbardHamiltonian(object):
         if self.q[0] <= 0:
             if self.spin_size == 2:
                 if self.q[1] <= 0:
-                    self.q[1] = ntot / 2
+                    self.q[1] = ntot // 2
                 self.q[0] = ntot - self.q[1]
             else:
                 self.q[0] = ntot / 2


### PR DESCRIPTION
Spin-polarized calculations for molecules with an odd number of electrons should reflect this difference in the populations of the two spin components, rather than operating with fractional `q`-values. This branch fixes this by forcing integer division.