### PR TITLE
Intercell Zak phase calculations

### DIFF
--- a/hubbard/hamiltonian.py
+++ b/hubbard/hamiltonian.py
@@ -598,7 +598,7 @@ class HubbardHamiltonian(object):
         L = np.einsum('ia,ia,ib,ib->ab', evec, evec, evec, evec).real
         return ev, L
 
-    def get_Zak_phase(self, func=None, nk=51, sub='filled', eigvals=False):
+    def get_Zak_phase(self, func=None, nk=51, sub='filled', eigvals=False, intercell=True):
         """ Computes the Zak phase for 1D (periodic) systems using `sisl.physics.electron.berry_phase`
 
         Parameters
@@ -609,6 +609,10 @@ class HubbardHamiltonian(object):
             number of k-points generated using the parameterization
         sub: int, optional
             number of bands that will be summed to obtain the Zak phase
+        eigvals : bool, optional
+            return the eigenvalues of the product of the overlap matrices, see sisl.physics.electron.berry_phase
+        intercell : bool, optional
+            shifts the origin to the geometry center to compute the intercell Zak phase
 
         Notes
         -----
@@ -620,12 +624,15 @@ class HubbardHamiltonian(object):
         Zak: float
             Zak phase for the 1D system
         """
-
+        H = self.H.copy()
+        if intercell:
+            # shift origin to the geometric center
+            H.geometry.xyz -= H.geometry.center()
         if not func:
             # Discretize kx over [0.0, 1.0[ in Nx-1 segments (1BZ)
             def func(sc, frac):
                 return [frac, 0, 0]
-        bz = sisl.BrillouinZone.parametrize(self.H, func, nk)
+        bz = sisl.BrillouinZone.parametrize(H, func, nk)
         if sub == 'filled':
             # Sum up over all occupied bands:
             sub = np.arange(int(round(self.q[0])))

--- a/hubbard/hamiltonian.py
+++ b/hubbard/hamiltonian.py
@@ -598,21 +598,23 @@ class HubbardHamiltonian(object):
         L = np.einsum('ia,ia,ib,ib->ab', evec, evec, evec, evec).real
         return ev, L
 
-    def get_Zak_phase(self, func=None, nk=51, sub='filled', eigvals=False, method='zak'):
+    def get_Zak_phase(self, func=None, axis=0, nk=51, sub='filled', eigvals=False, method='zak'):
         """ Computes the Zak phase for 1D (periodic) systems using `sisl.physics.electron.berry_phase`
 
         Parameters
         ----------
-        func: callable, optional
+        func : callable, optional
             function that creates a list of parametrized k-points to generate a new `sisl.physics.BrillouinZone` object parametrized in `N` separations
-        nk: int, optional
+        axis : int, optional
+            index for the periodic direction
+        nk : int, optional
             number of k-points generated using the parameterization
-        sub: int, optional
+        sub : int, optional
             number of bands that will be summed to obtain the Zak phase
         eigvals : bool, optional
             return the eigenvalues of the product of the overlap matrices, see sisl.physics.electron.berry_phase
         method : {'zak', 'zak:origin'}
-            whether to compute intercell Zak phase (default) or the total Zak phase including the origin-dependent contribution,
+            whether to compute intercell Zak phase (default) or the origin-dependent (total) Zak phase,
             see `sisl.electron.berry_phase` for details.
 
         Notes
@@ -628,7 +630,9 @@ class HubbardHamiltonian(object):
         if not func:
             # Discretize kx over [0.0, 1.0[ in Nx-1 segments (1BZ)
             def func(sc, frac):
-                return [frac, 0, 0]
+                f = [0, 0, 0]
+                f[axis] = frac
+                return f
         bz = sisl.BrillouinZone.parametrize(self.H, func, nk)
         if sub == 'filled':
             # Sum up over all occupied bands:

--- a/tests/test-zak.py
+++ b/tests/test-zak.py
@@ -20,7 +20,7 @@ zak = H.get_Zak_phase(axis=1)
 zako = H.get_Zak_phase(axis=1, method='zak:origin')
 print(f'SSH topo : zak={zak:7.3f}, zak:origin={zako:7.3f}')
 
-# SSH model, topological cell
+# SSH model, trivial cell
 g = sisl.Geometry([[0, 0, 0], [0, 1.42, 0]], sisl.Atom(6, 1.001), sc=[10, 3, 10])
 g.set_nsc([1, 3, 1])
 H0 = sp2(g)

--- a/tests/test-zak.py
+++ b/tests/test-zak.py
@@ -1,0 +1,12 @@
+from hubbard import HubbardHamiltonian, sp2
+import numpy as np
+import sisl
+
+for w in range(1, 25, 2):
+    g = sisl.geom.agnr(w)
+    H0 = sp2(g)
+    H = HubbardHamiltonian(H0, U=0)
+    #(self, func=None, nk=51, sub='filled', eigvals=False, method='zak')
+    zak = H.get_Zak_phase()
+    zako = H.get_Zak_phase(method='zak:origin')
+    print(f'width={w:3}, zak={zak:7.3f}, zak:origin={zako:7.3f}')

--- a/tests/test-zak.py
+++ b/tests/test-zak.py
@@ -10,3 +10,21 @@ for w in range(1, 25, 2):
     zak = H.get_Zak_phase()
     zako = H.get_Zak_phase(method='zak:origin')
     print(f'width={w:3}, zak={zak:7.3f}, zak:origin={zako:7.3f}')
+
+# SSH model, topological cell
+g = sisl.Geometry([[0, 0, 0], [0, 1.65, 0]], sisl.Atom(6, 1.001), sc=[10, 3, 10])
+g.set_nsc([1, 3, 1])
+H0 = sp2(g)
+H = HubbardHamiltonian(H0, U=0)
+zak = H.get_Zak_phase(axis=1)
+zako = H.get_Zak_phase(axis=1, method='zak:origin')
+print(f'SSH topo : zak={zak:7.3f}, zak:origin={zako:7.3f}')
+
+# SSH model, topological cell
+g = sisl.Geometry([[0, 0, 0], [0, 1.42, 0]], sisl.Atom(6, 1.001), sc=[10, 3, 10])
+g.set_nsc([1, 3, 1])
+H0 = sp2(g)
+H = HubbardHamiltonian(H0, U=0)
+zak = H.get_Zak_phase(axis=1)
+zako = H.get_Zak_phase(axis=1, method='zak:origin')
+print(f'SSH triv : zak={zak:7.3f}, zak:origin={zako:7.3f}')


### PR DESCRIPTION
Following the discussion on discord with @pfebrer and @zerothi, this branch enables the possibility of a coordinate shift to bring the origin of the cell to the (possible) mirror/inversion symmetric point of the geometry. In this way the computed Zak phase corresponds to the (origin-independent) intercell part.

Note that I also propose `intercell=True` to be the default.