### PR TITLE
Parametrize and Berry-phase gauge changed in sisl

### DIFF
--- a/hubbard/hamiltonian.py
+++ b/hubbard/hamiltonian.py
@@ -629,9 +629,9 @@ class HubbardHamiltonian(object):
         """
         if not func:
             # Discretize kx over [0.0, 1.0[ in Nx-1 segments (1BZ)
-            def func(sc, frac):
+            def func(sc, N, i):
                 f = [0, 0, 0]
-                f[axis] = frac
+                f[axis] = i / N
                 return f
         bz = sisl.BrillouinZone.parametrize(self.H, func, nk)
         if sub == 'filled':

--- a/hubbard/hamiltonian.py
+++ b/hubbard/hamiltonian.py
@@ -598,8 +598,8 @@ class HubbardHamiltonian(object):
         L = np.einsum('ia,ia,ib,ib->ab', evec, evec, evec, evec).real
         return ev, L
 
-    def get_Zak_phase(self, func=None, axis=0, nk=51, sub='filled', eigvals=False, method='zak'):
-        """ Computes the Zak phase for 1D (periodic) systems using `sisl.physics.electron.berry_phase`
+    def get_Zak_phase(self, func=None, axis=0, nk=51, sub='filled', eigvals=False):
+        """ Computes the intercell Zak phase for 1D (periodic) systems using `sisl.physics.electron.berry_phase`
 
         Parameters
         ----------
@@ -613,9 +613,6 @@ class HubbardHamiltonian(object):
             number of bands that will be summed to obtain the Zak phase
         eigvals : bool, optional
             return the eigenvalues of the product of the overlap matrices, see sisl.physics.electron.berry_phase
-        method : {'zak', 'zak:origin'}
-            whether to compute intercell Zak phase (default) or the origin-dependent (total) Zak phase,
-            see `sisl.electron.berry_phase` for details.
 
         Notes
         -----
@@ -625,7 +622,7 @@ class HubbardHamiltonian(object):
         Returns
         -------
         Zak: float
-            Zak phase for the 1D system
+            Intercell Zak phase for the 1D system
         """
         if not func:
             # Discretize kx over [0.0, 1.0[ in Nx-1 segments (1BZ)
@@ -637,7 +634,7 @@ class HubbardHamiltonian(object):
         if sub == 'filled':
             # Sum up over all occupied bands:
             sub = np.arange(int(round(self.q[0])))
-        return sisl.electron.berry_phase(bz, sub=sub, eigvals=eigvals, method=method)
+        return sisl.electron.berry_phase(bz, sub=sub, eigvals=eigvals)
 
     def get_bond_order(self, format='csr', midgap=0.):
         """ Compute Huckel bond order

--- a/tests/test-zak.py
+++ b/tests/test-zak.py
@@ -6,10 +6,8 @@ for w in range(1, 25, 2):
     g = sisl.geom.agnr(w)
     H0 = sp2(g)
     H = HubbardHamiltonian(H0, U=0)
-    #(self, func=None, nk=51, sub='filled', eigvals=False, method='zak')
     zak = H.get_Zak_phase()
-    zako = H.get_Zak_phase(method='zak:origin')
-    print(f'width={w:3}, zak={zak:7.3f}, zak:origin={zako:7.3f}')
+    print(f'width={w:3}, zak={zak:7.3f}')
 
 # SSH model, topological cell
 g = sisl.Geometry([[0, 0, 0], [0, 1.65, 0]], sisl.Atom(6, 1.001), sc=[10, 3, 10])
@@ -17,8 +15,7 @@ g.set_nsc([1, 3, 1])
 H0 = sp2(g)
 H = HubbardHamiltonian(H0, U=0)
 zak = H.get_Zak_phase(axis=1)
-zako = H.get_Zak_phase(axis=1, method='zak:origin')
-print(f'SSH topo : zak={zak:7.3f}, zak:origin={zako:7.3f}')
+print(f'SSH topo : zak={zak:7.3f}')
 
 # SSH model, trivial cell
 g = sisl.Geometry([[0, 0, 0], [0, 1.42, 0]], sisl.Atom(6, 1.001), sc=[10, 3, 10])
@@ -26,5 +23,4 @@ g.set_nsc([1, 3, 1])
 H0 = sp2(g)
 H = HubbardHamiltonian(H0, U=0)
 zak = H.get_Zak_phase(axis=1)
-zako = H.get_Zak_phase(axis=1, method='zak:origin')
-print(f'SSH triv : zak={zak:7.3f}, zak:origin={zako:7.3f}')
+print(f'SSH triv : zak={zak:7.3f}')


### PR DESCRIPTION
This branch brings `hubbard` up to the current sisl version:
* `parametrize` was changed in https://github.com/zerothi/sisl/commit/873fd40754fadfb845a047dbe67638d53e83b1c4.
* the parameter `method='zak:origin'` was removed in https://github.com/zerothi/sisl/commit/57c3c607a0b0b068d41a31be9986dab6ad132b4f