### PR TITLE
Fix DOS plot

### DIFF
--- a/hubbard/grid.py
+++ b/hubbard/grid.py
@@ -1,0 +1,61 @@
+import numpy as np
+import sisl
+
+
+def real_space_grid(geometry, v, grid_unit, xmin, xmax, ymin, ymax, z=1.1, mode='wavefunction', **kwargs):
+    """
+    Parameters
+    ----------
+    g : sisl.Geometry
+    v : numpy.array
+    grid_unit: 3-array-like
+    mode: str, optinoal
+        to build the grid from sisl.electron.wavefunction object (``mode=wavefunction``)
+        or from the sisl.physics.DensityMatrix (``mode=`charge`), e.g. for charge-related plots
+    sc: sisl.SuperCell, optional
+        super cell, defaults to the sc saved in the geometry
+    """
+    # Create a temporary copy of the geometry
+    g = geometry.copy()
+
+    # Set new sc to create real-space grid
+    sc = sisl.SuperCell([xmax-xmin, ymax-ymin, 1000], origin=[0, 0, -z])
+    g.set_sc(sc)
+
+    # Move geometry within the supercell
+    g = g.move([-xmin, -ymin, -np.amin(g.xyz[:, 2])])
+    # Make z~0 -> z = 0
+    g.xyz[np.where(np.abs(g.xyz[:, 2]) < 1e-3), 2] = 0
+
+    # Create the real-space grid
+    grid = sisl.Grid(grid_unit, sc=sc, geometry=g)
+
+    if mode in ['wavefunction']:
+        if isinstance(v, sisl.physics.electron.EigenstateElectron):
+            # Set parent geometry equal to the temporary one
+            v.parent = g
+            v.wavefunction(grid)
+        else:
+            # In case v is a vector
+            sisl.electron.wavefunction(v, grid, geometry=g)
+    elif mode in ['charge']:
+        # The input vector v corresponds to charge-related quantities
+        # including spin-polarization understood as charge_up - charge_dn
+        D = sisl.physics.DensityMatrix(g)
+        a = np.arange(len(D))
+        D.D[a, a] = v
+        D.density(grid)
+    
+    if 'smooth' in kwargs:
+        # Smooth grid with gaussian function
+        if 'r_smooth' in kwargs:
+            r_smooth = kwargs['r_smooth']
+        else:
+            r_smooth = 0.7
+        grid = grid.smooth(method='gaussian', r=r_smooth)
+
+    # Slice it to obtain a 2D grid
+    grid = grid.grid[:, :, 0].T.real
+
+    del g
+    return grid

--- a/hubbard/grid.py
+++ b/hubbard/grid.py
@@ -2,7 +2,7 @@ import numpy as np
 import sisl
 
 
-def real_space_grid(geometry, vector, shape, xmin, xmax, ymin, ymax, z, mode='wavefunction', **kwargs):
+def real_space_grid(geometry, sc, vector, shape, mode='wavefunction', **kwargs):
     """
     Parameters
     ----------
@@ -13,8 +13,8 @@ def real_space_grid(geometry, vector, shape, xmin, xmax, ymin, ymax, z, mode='wa
     shape: float or (3,) of int
         the shape of the grid. A float specifies the grid spacing in Angstrom, while a list of integers specifies the exact grid size
         (see `sisl.Grid`)
-    z: float
-        z coordinate
+    sc:
+        sisl.SuperCell object of the grid
     mode: str, optional
         to build the grid from sisl.electron.wavefunction object (``mode=wavefunction``)
         or from the sisl.physics.DensityMatrix (``mode=`charge`), e.g. for charge-related plots
@@ -27,11 +27,7 @@ def real_space_grid(geometry, vector, shape, xmin, xmax, ymin, ymax, z, mode='wa
     g = geometry.copy()
 
     # Set new sc to create real-space grid
-    sc = sisl.SuperCell([xmax-xmin, ymax-ymin, 1000], origin=[0, 0, -z])
     g.set_sc(sc)
-
-    # Move geometry within the supercell
-    g = g.move([-xmin, -ymin, -np.amin(g.xyz[:, 2])])
 
     # Create the real-space grid
     grid = sisl.Grid(shape, sc=sc, geometry=g)

--- a/hubbard/hamiltonian.py
+++ b/hubbard/hamiltonian.py
@@ -386,7 +386,7 @@ class HubbardHamiltonian(object):
         midgap = (HOMO + LUMO) * 0.5
         return midgap
 
-    def fermi_level(self, q=[None, None], dist='fermi_dirac'):
+    def fermi_level(self, q=[None, None], distribution='fermi_dirac'):
         """ Find the fermi level for a certain charge `q` at a certain `kT`
 
         Parameters
@@ -395,7 +395,7 @@ class HubbardHamiltonian(object):
             charge per spin channel. First index for spin up, second index for dn
             If the Hamiltonian is unpolarized q should have only one component
             otherwise it will take the first one
-        dist: str or sisl.distribution, optional
+        distribution: str or sisl.distribution, optional
             distribution function
 
         See Also
@@ -411,10 +411,10 @@ class HubbardHamiltonian(object):
         for i in range(self.spin_size):
             if Q[i] is None:
                 Q[i] = self.q[i]
-        if isinstance(dist, str):
-            dist = sisl.get_distribution(dist, smearing=self.kT)
+        if isinstance(distribution, str):
+            distribution = sisl.get_distribution(distribution, smearing=self.kT)
 
-        Ef = self.H.fermi_level(self.mp, q=Q, distribution=dist)
+        Ef = self.H.fermi_level(self.mp, q=Q, distribution=distribution)
         return Ef
 
     def shift(self, E):
@@ -795,7 +795,7 @@ class HubbardHamiltonian(object):
         else:
             return S_MFH
 
-    def DOS(self, egrid, eta=1e-3, spin=[0, 1], dist='Lorentzian', eref=0.):
+    def DOS(self, egrid, eta=1e-3, spin=[0, 1], distribution='Lorentzian'):
         """ Obtains the density of states (DOS) of the system with a distribution function
 
         Parameters
@@ -807,10 +807,8 @@ class HubbardHamiltonian(object):
         spin: int, optional
             If spin=0(1) it calculates the DOS for up (down) electrons in the system.
             If spin is not specified it returns DOS_up + DOS_dn.
-        dist: str or sisl.physics.distribution, optional
+        distribution: str or sisl.physics.distribution, optional
             distribution for the convolution, defaults to Lorentzian
-        eref: float, optional
-            energy reference, defaults to zero
 
         See Also
         ------------
@@ -830,19 +828,19 @@ class HubbardHamiltonian(object):
         if not isinstance(egrid, np.ndarray):
             egrid = np.array(egrid)
 
-        if isinstance(dist, str):
-            dist = sisl.get_distribution(dist, smearing=eta)
+        if isinstance(distribution, str):
+            distribution = sisl.get_distribution(distribution, smearing=eta)
         else:
             warnings.warn("Using distribution created outside this function. The energy reference may be shifted if the distribution is calculated with respect to a non-zero energy value")
 
         # Obtain eigenvalues
         dos = 0
         for ispin in spin:
-            eig = self.eigh(spin=ispin) - eref
-            dos += sisl.electron.DOS(egrid, eig, distribution=dist)
+            eig = self.eigh(spin=ispin)
+            dos += sisl.electron.DOS(egrid, eig, distribution=distribution)
         return dos
 
-    def PDOS(self, egrid, eta=1e-3, spin=[0, 1], dist='Lorentzian', eref=0.):
+    def PDOS(self, egrid, eta=1e-3, spin=[0, 1], distribution='Lorentzian'):
         """ Obtains the projected density of states (PDOS) of the system with a distribution function
 
         Parameters
@@ -854,10 +852,8 @@ class HubbardHamiltonian(object):
         spin: int, optional
             If spin=0(1) it calculates the DOS for up (down) electrons in the system.
             If spin is not specified it returns DOS_up + DOS_dn.
-        dist: str or sisl.distribution, optional
+        distribution: str or sisl.distribution, optional
             distribution for the convolution, defaults to Lorentzian
-        eref: float, optional
-            energy reference, defaults to zero
 
         See Also
         ------------
@@ -877,8 +873,8 @@ class HubbardHamiltonian(object):
         if not isinstance(egrid, np.ndarray):
             egrid = np.array(egrid)
 
-        if isinstance(dist, str):
-            dist = sisl.get_distribution(dist, smearing=eta)
+        if isinstance(distribution, str):
+            distribution = sisl.get_distribution(distribution, smearing=eta)
         else:
             warnings.warn("Using distribution created outside this function. The energy reference may be shifted if the distribution is calculated with respect to a non-zero energy value")
 
@@ -886,7 +882,6 @@ class HubbardHamiltonian(object):
         pdos = 0
         for ispin in spin:
             ev, evec = self.eigh(eigvals_only=False, spin=ispin)
-            ev -= eref
-            pdos += sisl.physics.electron.PDOS(egrid, ev, evec.T, distribution=dist)
+            pdos += sisl.physics.electron.PDOS(egrid, ev, evec.T, distribution=distribution)
 
         return pdos

--- a/hubbard/negf.py
+++ b/hubbard/negf.py
@@ -121,7 +121,7 @@ class NEGF:
             if isinstance(elec_SE, (tuple, list)):
                 # here HH *must* be a HubbardHamiltonian (otherwise it will probably crash)
                 HH, semi_inf = elec_SE
-                Ef_elec = HH.fermi_level(q=HH.q, dist=dist)
+                Ef_elec = HH.fermi_level(q=HH.q, distribution=dist)
                 # Shift each electrode with its Fermi-level and chemical potential
                 # Since the electrodes are *bulk* i.e. the entire electronic structure
                 # is simply shifted

--- a/hubbard/plot/charge.py
+++ b/hubbard/plot/charge.py
@@ -27,6 +27,7 @@ class Charge(GeometryPlot):
         plot charge associated to one specific spin index, or both if ``spin=[0,1]``
     realspace: bool, optional
         if True it plots the total charge in a realspace grid. In other case it will be plotted as Mulliken populations
+        If True either a `sisl.SuperCell` (`sc` kwarg) or the `z` kwarg to slice the real space grid at the desired z coordinate needs to be passed
 
     """
 
@@ -59,8 +60,6 @@ class Charge(GeometryPlot):
         if realspace:
             if 'shape' not in kwargs:
                 kwargs['shape'] = [100,100,1]
-            if 'z' not in kwargs:
-                raise ValueError('z coordinate needs to be passed to slice the real space grid')
 
             if 'vmin' not in kwargs:
                 kwargs['vmin'] = 0
@@ -71,7 +70,7 @@ class Charge(GeometryPlot):
                 if 'z' in kwargs:
                     origin = [xmin, ymin, -kwargs['z']]
                 else:
-                    origin = [xmin, ymin, np.amin(HH.geometry.xyz[:,2])]
+                    raise ValueError('Either a SC or the z coordinate to slice the real space grid needs to be passed')
 
                 kwargs['sc'] = sisl.SuperCell([xmax-xmin, ymax-ymin, 1000], origin=origin)
 
@@ -104,8 +103,8 @@ class ChargeDifference(GeometryPlot):
         a role in the Hubbard Hamiltonian. If ext_geom is passed it plots the full sp2 carbon system
         otherwise it only uses the geometry associated to the `hubbard.HubbardHamiltonian` (carbon backbone)
     realspace: bool, optional
-        if True it plots the charge difference in a realspace grid. In other case it will be plotted as Mulliken
-        In this case the `z` kwarg needs to be passed to slice the real space grid at the desired z coordinate
+        if True it plots the charge difference in a realspace grid. In other case it will be plotted as Mulliken populations
+        If True either a `sisl.SuperCell` (`sc` kwarg) or the `z` kwarg to slice the real space grid at the desired z coordinate needs to be passed
     """
 
     def __init__(self, HH, ext_geom=None, realspace=False, **kwargs):
@@ -139,10 +138,6 @@ class ChargeDifference(GeometryPlot):
             if 'shape' not in kwargs:
                 kwargs['shape'] = [100,100,1]
 
-            if 'z' not in kwargs:
-                raise ValueError('z coordinate needs to be passed to slice the real space grid')
-
-
             if 'vmin' not in kwargs:
                 kwargs['vmin'] = 0
 
@@ -152,7 +147,7 @@ class ChargeDifference(GeometryPlot):
                 if 'z' in kwargs:
                     origin = [xmin, ymin, -kwargs['z']]
                 else:
-                    origin = [xmin, ymin, np.amin(HH.geometry.xyz[:,2])]
+                    raise ValueError('Either a SC or the z coordinate to slice the real space grid needs to be passed')
 
                 kwargs['sc'] = sisl.SuperCell([xmax-xmin, ymax-ymin, 1000], origin=origin)
 
@@ -188,7 +183,7 @@ class SpinPolarization(GeometryPlot):
         otherwise it only uses the geometry associated to the `hubbard.HubbardHamiltonian` (carbon backbone)
     realspace: bool, optional
         if True it plots the spin polarization in a realspace grid. In other case it will be plotted as Mulliken populations
-        In this case the `z` kwarg needs to be passed to slice the real space grid at the desired z coordinate
+        If True either a `sisl.SuperCell` (`sc` kwarg) or the `z` kwarg to slice the real space grid at the desired z coordinate needs to be passed
     """
 
     def __init__(self, HH, ext_geom=None, realspace=False, **kwargs):
@@ -217,8 +212,6 @@ class SpinPolarization(GeometryPlot):
         if realspace:
             if 'shape' not in kwargs:
                 kwargs['shape'] = [100,100,1]
-            if 'z' not in kwargs:
-                raise ValueError('z coordinate needs to be passed to slice the real space grid')
 
             if 'vmin' not in kwargs:
                 kwargs['vmin'] = 0
@@ -229,7 +222,7 @@ class SpinPolarization(GeometryPlot):
                 if 'z' in kwargs:
                     origin = [xmin, ymin, -kwargs['z']]
                 else:
-                    origin = [xmin, ymin, np.amin(HH.geometry.xyz[:,2])]
+                    raise ValueError('Either a SC or the z coordinate to slice the real space grid needs to be passed')
 
                 kwargs['sc'] = sisl.SuperCell([xmax-xmin, ymax-ymin, 1000], origin=origin)
 

--- a/hubbard/plot/charge.py
+++ b/hubbard/plot/charge.py
@@ -67,10 +67,21 @@ class Charge(GeometryPlot):
 
             xmin, xmax, ymin, ymax = self.xmin, self.xmax, self.ymin, self.ymax
 
-            grid = real_space_grid(self.geometry, chg, kwargs['shape'], xmin, xmax, ymin, ymax, kwargs['z'], mode='charge')
+            if 'sc' not in kwargs:
+                if 'z' in kwargs:
+                    origin = [xmin, ymin, -kwargs['z']]
+                else:
+                    origin = [xmin, ymin, np.amin(HH.geometry.xyz[:,2])]
+
+                kwargs['sc'] = sisl.SuperCell([xmax-xmin, ymax-ymin, 1000], origin=origin)
+
+            if 'axis' not in kwargs:
+                kwargs['axis'] = 2
+
+            grid = real_space_grid(self.geometry, kwargs['sc'], chg, kwargs['shape'], mode='charge')
 
             # Slice it to obtain a 2D grid
-            slice_grid = grid.grid[:, :, 0].T.real
+            slice_grid = grid.swapaxes(kwargs['axis'], 2).grid[:, :, 0].T.real
 
             self.__realspace__(slice_grid, **kwargs)
 
@@ -137,10 +148,22 @@ class ChargeDifference(GeometryPlot):
 
             xmin, xmax, ymin, ymax = self.xmin, self.xmax, self.ymin, self.ymax
 
-            grid = real_space_grid(self.geometry, chg, kwargs['shape'], xmin, xmax, ymin, ymax, kwargs['z'], mode='charge')
+            if 'sc' not in kwargs:
+                if 'z' in kwargs:
+                    origin = [xmin, ymin, -kwargs['z']]
+                else:
+                    origin = [xmin, ymin, np.amin(HH.geometry.xyz[:,2])]
+
+                kwargs['sc'] = sisl.SuperCell([xmax-xmin, ymax-ymin, 1000], origin=origin)
+
+            if 'axis' not in kwargs:
+                kwargs['axis'] = 2
+
+            grid = real_space_grid(self.geometry, kwargs['sc'], chg, kwargs['shape'], mode='charge')
 
             # Slice it to obtain a 2D grid
-            slice_grid = grid.grid[:, :, 0].T.real
+            slice_grid = grid.swapaxes(kwargs['axis'],2).grid[:, :, 0].T.real
+
             self.__realspace__(slice_grid, **kwargs)
 
         else:
@@ -202,10 +225,23 @@ class SpinPolarization(GeometryPlot):
 
             xmin, xmax, ymin, ymax = self.xmin, self.xmax, self.ymin, self.ymax
 
-            grid = real_space_grid(self.geometry, chg, kwargs['shape'], xmin, xmax, ymin, ymax, kwargs['z'], mode='charge')
+            if 'sc' not in kwargs:
+                if 'z' in kwargs:
+                    origin = [xmin, ymin, -kwargs['z']]
+                else:
+                    origin = [xmin, ymin, np.amin(HH.geometry.xyz[:,2])]
+
+                kwargs['sc'] = sisl.SuperCell([xmax-xmin, ymax-ymin, 1000], origin=origin)
+
+
+            if 'axis' not in kwargs:
+                kwargs['axis'] = 2
+
+            grid = real_space_grid(self.geometry, kwargs['sc'], chg, kwargs['shape'], mode='charge')
 
             # Slice it to obtain a 2D grid
-            slice_grid = grid.grid[:, :, 0].T.real
+            slice_grid = grid.swapaxes(kwargs['axis'],2).grid[:, :, 0].T.real
+
             self.__realspace__(slice_grid, **kwargs)
 
         else:

--- a/hubbard/plot/charge.py
+++ b/hubbard/plot/charge.py
@@ -57,18 +57,22 @@ class Charge(GeometryPlot):
             chg[ia] += HH.n[0, io] + HH.n[1, io]
 
         if realspace:
-            if 'grid_unit' not in kwargs:
-                kwargs['grid_unit'] = [100,100,1]
+            if 'shape' not in kwargs:
+                kwargs['shape'] = [100,100,1]
             if 'z' not in kwargs:
-                kwargs['z'] = 1.1
+                raise ValueError('z coordinate needs to be passed to slice the real space grid')
 
             if 'vmin' not in kwargs:
                 kwargs['vmin'] = 0
 
             xmin, xmax, ymin, ymax = self.xmin, self.xmax, self.ymin, self.ymax
 
-            grid = real_space_grid(self.geometry, chg, kwargs['grid_unit'], xmin, xmax, ymin, ymax, z=kwargs['z'], mode='charge')
-            self.__realspace__(grid, **kwargs)
+            grid = real_space_grid(self.geometry, chg, kwargs['shape'], xmin, xmax, ymin, ymax, kwargs['z'], mode='charge')
+
+            # Slice it to obtain a 2D grid
+            slice_grid = grid.grid[:, :, 0].T.real
+
+            self.__realspace__(slice_grid, **kwargs)
 
         else:
             self.__orbitals__(chg, **kwargs)
@@ -89,7 +93,8 @@ class ChargeDifference(GeometryPlot):
         a role in the Hubbard Hamiltonian. If ext_geom is passed it plots the full sp2 carbon system
         otherwise it only uses the geometry associated to the `hubbard.HubbardHamiltonian` (carbon backbone)
     realspace: bool, optional
-        if True it plots the charge difference in a realspace grid. In other case it will be plotted as Mulliken populations
+        if True it plots the charge difference in a realspace grid. In other case it will be plotted as Mulliken
+        In this case the `z` kwarg needs to be passed to slice the real space grid at the desired z coordinate
     """
 
     def __init__(self, HH, ext_geom=None, realspace=False, **kwargs):
@@ -120,18 +125,23 @@ class ChargeDifference(GeometryPlot):
         chg -= q
 
         if realspace:
-            if 'grid_unit' not in kwargs:
-                kwargs['grid_unit'] = [100,100,1]
+            if 'shape' not in kwargs:
+                kwargs['shape'] = [100,100,1]
+
             if 'z' not in kwargs:
-                kwargs['z'] = 1.1
+                raise ValueError('z coordinate needs to be passed to slice the real space grid')
+
 
             if 'vmin' not in kwargs:
                 kwargs['vmin'] = 0
 
             xmin, xmax, ymin, ymax = self.xmin, self.xmax, self.ymin, self.ymax
 
-            grid = real_space_grid(self.geometry, chg, kwargs['grid_unit'], xmin, xmax, ymin, ymax, z=kwargs['z'], mode='charge')
-            self.__realspace__(grid, **kwargs)
+            grid = real_space_grid(self.geometry, chg, kwargs['shape'], xmin, xmax, ymin, ymax, kwargs['z'], mode='charge')
+
+            # Slice it to obtain a 2D grid
+            slice_grid = grid.grid[:, :, 0].T.real
+            self.__realspace__(slice_grid, **kwargs)
 
         else:
             # Default symmetric colorscale
@@ -155,6 +165,7 @@ class SpinPolarization(GeometryPlot):
         otherwise it only uses the geometry associated to the `hubbard.HubbardHamiltonian` (carbon backbone)
     realspace: bool, optional
         if True it plots the spin polarization in a realspace grid. In other case it will be plotted as Mulliken populations
+        In this case the `z` kwarg needs to be passed to slice the real space grid at the desired z coordinate
     """
 
     def __init__(self, HH, ext_geom=None, realspace=False, **kwargs):
@@ -181,18 +192,21 @@ class SpinPolarization(GeometryPlot):
             chg[ia] += (HH.n[0, io] - HH.n[1, io])
 
         if realspace:
-            if 'grid_unit' not in kwargs:
-                kwargs['grid_unit'] = [100,100,1]
+            if 'shape' not in kwargs:
+                kwargs['shape'] = [100,100,1]
             if 'z' not in kwargs:
-                kwargs['z'] = 1.1
+                raise ValueError('z coordinate needs to be passed to slice the real space grid')
 
             if 'vmin' not in kwargs:
                 kwargs['vmin'] = 0
 
             xmin, xmax, ymin, ymax = self.xmin, self.xmax, self.ymin, self.ymax
 
-            grid = real_space_grid(self.geometry, chg, kwargs['grid_unit'], xmin, xmax, ymin, ymax, z=kwargs['z'], mode='charge')
-            self.__realspace__(grid, **kwargs)
+            grid = real_space_grid(self.geometry, chg, kwargs['shape'], xmin, xmax, ymin, ymax, kwargs['z'], mode='charge')
+
+            # Slice it to obtain a 2D grid
+            slice_grid = grid.grid[:, :, 0].T.real
+            self.__realspace__(slice_grid, **kwargs)
 
         else:
             # Default symmetric colorscale

--- a/hubbard/plot/charge.py
+++ b/hubbard/plot/charge.py
@@ -2,6 +2,7 @@ import matplotlib.pyplot as plt
 from hubbard.plot import GeometryPlot
 import sisl
 import numpy as np
+from hubbard.grid import *
 
 __all__ = ['Charge', 'ChargeDifference', 'SpinPolarization']
 
@@ -56,7 +57,18 @@ class Charge(GeometryPlot):
             chg[ia] += HH.n[0, io] + HH.n[1, io]
 
         if realspace:
-            self.__realspace__(chg, mode='charge', **kwargs)
+            if 'grid_unit' not in kwargs:
+                kwargs['grid_unit'] = [100,100,1]
+            if 'z' not in kwargs:
+                kwargs['z'] = 1.1
+
+            if 'vmin' not in kwargs:
+                kwargs['vmin'] = 0
+
+            xmin, xmax, ymin, ymax = self.xmin, self.xmax, self.ymin, self.ymax
+
+            grid = real_space_grid(self.geometry, chg, kwargs['grid_unit'], xmin, xmax, ymin, ymax, z=kwargs['z'], mode='charge')
+            self.__realspace__(grid, **kwargs)
 
         else:
             self.__orbitals__(chg, **kwargs)
@@ -108,7 +120,18 @@ class ChargeDifference(GeometryPlot):
         chg -= q
 
         if realspace:
-            self.__realspace__(chg, mode='charge', **kwargs)
+            if 'grid_unit' not in kwargs:
+                kwargs['grid_unit'] = [100,100,1]
+            if 'z' not in kwargs:
+                kwargs['z'] = 1.1
+
+            if 'vmin' not in kwargs:
+                kwargs['vmin'] = 0
+
+            xmin, xmax, ymin, ymax = self.xmin, self.xmax, self.ymin, self.ymax
+
+            grid = real_space_grid(self.geometry, chg, kwargs['grid_unit'], xmin, xmax, ymin, ymax, z=kwargs['z'], mode='charge')
+            self.__realspace__(grid, **kwargs)
 
         else:
             # Default symmetric colorscale
@@ -158,7 +181,18 @@ class SpinPolarization(GeometryPlot):
             chg[ia] += (HH.n[0, io] - HH.n[1, io])
 
         if realspace:
-            self.__realspace__(chg, mode='charge', **kwargs)
+            if 'grid_unit' not in kwargs:
+                kwargs['grid_unit'] = [100,100,1]
+            if 'z' not in kwargs:
+                kwargs['z'] = 1.1
+
+            if 'vmin' not in kwargs:
+                kwargs['vmin'] = 0
+
+            xmin, xmax, ymin, ymax = self.xmin, self.xmax, self.ymin, self.ymax
+
+            grid = real_space_grid(self.geometry, chg, kwargs['grid_unit'], xmin, xmax, ymin, ymax, z=kwargs['z'], mode='charge')
+            self.__realspace__(grid, **kwargs)
 
         else:
             # Default symmetric colorscale

--- a/hubbard/plot/charge.py
+++ b/hubbard/plot/charge.py
@@ -56,7 +56,7 @@ class Charge(GeometryPlot):
             chg[ia] += HH.n[0, io] + HH.n[1, io]
 
         if realspace:
-            self.__realspace__(chg, density=True, **kwargs)
+            self.__realspace__(chg, mode='charge', **kwargs)
 
         else:
             self.__orbitals__(chg, **kwargs)
@@ -108,7 +108,7 @@ class ChargeDifference(GeometryPlot):
         chg -= q
 
         if realspace:
-            self.__realspace__(chg, density=True, **kwargs)
+            self.__realspace__(chg, mode='charge', **kwargs)
 
         else:
             # Default symmetric colorscale
@@ -158,7 +158,7 @@ class SpinPolarization(GeometryPlot):
             chg[ia] += (HH.n[0, io] - HH.n[1, io])
 
         if realspace:
-            self.__realspace__(chg, density=True, **kwargs)
+            self.__realspace__(chg, mode='charge', **kwargs)
 
         else:
             # Default symmetric colorscale

--- a/hubbard/plot/plot.py
+++ b/hubbard/plot/plot.py
@@ -1,4 +1,5 @@
 import numpy as np
+import sisl
 import matplotlib
 import matplotlib.pyplot as plt
 import matplotlib.patches as patches
@@ -229,61 +230,18 @@ class GeometryPlot(Plot):
                 if 'label' in kwargs:
                     self.set_colorbar_ylabel(kwargs['label'])
 
-    def __realspace__(self, v, z=1.1, grid_unit=[100, 100, 1], smooth=False, mode='wavefunction', **kwargs):
-
-        def real_space_grid(v, grid_unit, mode):
-            import sisl
-
-            # Create a temporary copy of the geometry
-            g = self.geometry.copy()
-
-            # Set new sc to create real-space grid
-            sc = sisl.SuperCell([self.xmax-self.xmin, self.ymax-self.ymin, 1000], origin=[0, 0, -z])
-            g.set_sc(sc)
-
-            # Move geometry within the supercell
-            g = g.move([-self.xmin, -self.ymin, -np.amin(g.xyz[:, 2])])
-            # Make z~0 -> z = 0
-            g.xyz[np.where(np.abs(g.xyz[:, 2]) < 1e-3), 2] = 0
-
-            # Create the real-space grid
-            grid = sisl.Grid(grid_unit, sc=g.sc, geometry=g)
-
-            if mode in ['wavefunction', 'density']:
-                if isinstance(v, sisl.physics.electron.EigenstateElectron):
-                    # Set parent geometry equal to the temporary one
-                    v.parent = g
-                    v.wavefunction(grid)
-                else:
-                    # In case v is a vector
-                    sisl.electron.wavefunction(v, grid, geometry=g)
-            elif mode in ['charge']:
-                D = sisl.physics.DensityMatrix(g)
-                a = np.arange(len(D))
-                D.D[a, a] = v
-                D.density(grid)
-
-            del g
-            return grid
-
-        grid = real_space_grid(v, grid_unit, mode)
-        if smooth:
-            # Smooth grid with gaussian function
-            if 'r_smooth' in kwargs:
-                r_smooth = kwargs['r_smooth']
-            else:
-                r_smooth = 0.7
-            grid = grid.smooth(method='gaussian', r=r_smooth)
-
-        slice_grid = grid.grid[:, :, 0].T.real
-
-        if mode in ['density']:
-            slice_grid = slice_grid**2
+    def __realspace__(self, grid, **kwargs):
+        """
+        Parameters
+        ----------
+        grid: numpy.ndarray
+            real space grid to be plotted as a colormap (imshow plot)
+        """
 
         if 'vmax' in kwargs:
             vmax = kwargs['vmax']
         else:
-            vmax = np.amax(np.absolute(slice_grid))
+            vmax = np.amax(np.absolute(grid))
 
         if 'vmin' in kwargs:
             vmin = kwargs['vmin']
@@ -292,7 +250,7 @@ class GeometryPlot(Plot):
 
         # Plot only the real part of the grid
         # The image will be created in an imshow layer (stored in self.imshow)
-        self.imshow = self.axes.imshow(slice_grid, cmap='seismic', origin='lower',
+        self.imshow = self.axes.imshow(grid, cmap='seismic', origin='lower',
                               vmax=vmax, vmin=vmin, extent=self.extent)
         # Colorbars
         if 'colorbar' in kwargs:

--- a/hubbard/plot/spectrum.py
+++ b/hubbard/plot/spectrum.py
@@ -208,8 +208,8 @@ class LDOS_from_eigenstate(GeometryPlot):
                 dos = WF[:,i]
                 grid_i = real_space_grid(self.geometry, dos, kwargs['shape'], xmin, xmax, ymin, ymax, kwargs['z'], mode='wavefunction')
                 # Slice it to obtain a 2D grid
-                slice_grid = grid_i.grid[:, :, 0].T.real
-                grid += slice_grid ** 2
+                slice_grid = grid_i.grid[:, :, 0].T
+                grid += slice_grid.real**2 + slice_grid.imag**2
 
             self.__realspace__(grid, **kwargs)
             self.imshow.set_cmap(plt.cm.afmhot)
@@ -300,8 +300,8 @@ class LDOS(GeometryPlot):
                     f = sisl.get_distribution(distribution, smearing=eta, x0=ev[ni])
                     weight = f(E)
                     # Slice it to obtain a 2D grid
-                    slice_grid = grid_n.grid[:, :, 0].T.real
-                    grid += (slice_grid ** 2) * weight
+                    slice_grid = grid_n.grid[:, :, 0].T
+                    grid += (slice_grid.real**2 + slice_grid.imag**2) * weight
 
             self.__realspace__(grid, **kwargs)
             self.imshow.set_cmap(plt.cm.afmhot)

--- a/hubbard/plot/spectrum.py
+++ b/hubbard/plot/spectrum.py
@@ -167,6 +167,7 @@ class LDOS_from_eigenstate(GeometryPlot):
     realspace:
         If True it will plot the LDOS in a realspace grid otherwise it plots it as a scatter plot (PDOS)
         with varying size depending on the PDOS numerical value
+        In this case either a `sisl.SuperCell` (`sc` kwarg) or the `z` kwarg to slice the real space grid at the desired z coordinate needs to be passed
     """
 
     def __init__(self, HH, wavefunction, sites=[], ext_geom=None, realspace=False, **kwargs):
@@ -203,7 +204,7 @@ class LDOS_from_eigenstate(GeometryPlot):
                 if 'z' in kwargs:
                     origin = [xmin, ymin, -kwargs['z']]
                 else:
-                    origin = [xmin, ymin, np.amin(HH.geometry.xyz[:,2])]
+                    raise ValueError('Either a SC or the z coordinate to slice the real space grid needs to be passed')
 
                 kwargs['sc'] = sisl.SuperCell([xmax-xmin, ymax-ymin, 1000], origin=origin)
 
@@ -252,7 +253,7 @@ class LDOS(GeometryPlot):
     realspace:
         If True it will plot the LDOS in a realspace grid otherwise it plots it as a scatter plot (PDOS)
         with varying size depending on the PDOS numerical value
-        In this case the `z` kwarg needs to be passed to slice the real space grid at the desired z coordinate
+        In this case either a `sisl.SuperCell` (`sc` kwarg) or the `z` kwarg to slice the real space grid at the desired z coordinate needs to be passed
 
     See Also
     ------------
@@ -281,8 +282,6 @@ class LDOS(GeometryPlot):
         if realspace:
             if 'shape' not in kwargs:
                 kwargs['shape'] = [100,100,1]
-            if 'z' not in kwargs:
-                  raise ValueError('z coordinate needs to be passed to slice the real space grid')
 
             if 'vmin' not in kwargs:
                 kwargs['vmin'] = 0
@@ -293,7 +292,7 @@ class LDOS(GeometryPlot):
                 if 'z' in kwargs:
                     origin = [xmin, ymin, -kwargs['z']]
                 else:
-                    origin = [xmin, ymin, np.amin(HH.geometry.xyz[:,2])]
+                    raise ValueError('Either a SC or the z coordinate to slice the real space grid needs to be passed')
 
                 kwargs['sc'] = sisl.SuperCell([xmax-xmin, ymax-ymin, 1000], origin=origin)
 

--- a/hubbard/plot/spectrum.py
+++ b/hubbard/plot/spectrum.py
@@ -198,7 +198,7 @@ class DOS_distribution(GeometryPlot):
         if realspace:
             if 'vmin' not in kwargs:
                 kwargs['vmin'] = 0
-            self.__realspace__(PDOS, density=True, **kwargs)
+            self.__realspace__(PDOS, mode='density', **kwargs)
             self.imshow.set_cmap(plt.cm.afmhot)
 
         else:

--- a/hubbard/plot/wavefunction.py
+++ b/hubbard/plot/wavefunction.py
@@ -56,10 +56,21 @@ class Wavefunction(GeometryPlot):
 
             xmin, xmax, ymin, ymax = self.xmin, self.xmax, self.ymin, self.ymax
 
-            grid = real_space_grid(self.geometry, wf, kwargs['shape'], xmin, xmax, ymin, ymax, kwargs['z'], mode='wavefunction')
+            if 'sc' not in kwargs:
+                if 'z' in kwargs:
+                    origin = [xmin, ymin, -kwargs['z']]
+                else:
+                    origin = [xmin, ymin, np.amin(HH.geometry.xyz[:,2])]
+
+                kwargs['sc'] = sisl.SuperCell([xmax-xmin, ymax-ymin, 1000], origin=origin)
+
+            if 'axis' not in kwargs:
+                kwargs['axis'] = 2
+
+            grid = real_space_grid(self.geometry, kwargs['sc'], wf, kwargs['shape'], mode='wavefunction')
 
             # Slice it to obtain a 2D grid
-            slice_grid = grid.grid[:, :, 0].T.real
+            slice_grid = grid.swapaxes(kwargs['axis'], 2).grid[:, :, 0].T.real
 
             self.__realspace__(slice_grid, **kwargs)
 

--- a/hubbard/plot/wavefunction.py
+++ b/hubbard/plot/wavefunction.py
@@ -2,6 +2,7 @@ import matplotlib.pyplot as plt
 from hubbard.plot import GeometryPlot
 import sisl
 import numpy as np
+from hubbard.grid import *
 
 __all__ = ['Wavefunction']
 
@@ -44,7 +45,18 @@ class Wavefunction(GeometryPlot):
 
     def plot_wf(self, HH, wf, cb_label=r'Phase', realspace=False, **kwargs):
         if realspace:
-            self.__realspace__(wf, **kwargs)
+            if 'grid_unit' not in kwargs:
+                kwargs['grid_unit'] = [100,100,1]
+            if 'z' not in kwargs:
+                kwargs['z'] = 1.1
+
+            if 'vmin' not in kwargs:
+                kwargs['vmin'] = 0
+
+            xmin, xmax, ymin, ymax = self.xmin, self.xmax, self.ymin, self.ymax
+
+            grid = real_space_grid(self.geometry, wf, kwargs['grid_unit'], xmin, xmax, ymin, ymax, z=kwargs['z'], mode='wavefunction')
+            self.__realspace__(grid, **kwargs)
 
             # Create custom map to differenciate it from polarization cmap
             import matplotlib.colors as mcolors

--- a/hubbard/plot/wavefunction.py
+++ b/hubbard/plot/wavefunction.py
@@ -23,7 +23,7 @@ class Wavefunction(GeometryPlot):
     Notes
     -----
     If `realspace` kwarg is passed it plots the wavefunction in a realspace grid
-    In this case the `z` kwarg needs to be passed to slice the real space grid at the desired z coordinate
+    In this case either a `sisl.SuperCell` (`sc` kwarg) or the `z` kwarg to slice the real space grid at the desired z coordinate needs to be passed
     In other case the wavefunction is plotted as a scatter plot, where the size of the blobs depend on the value
     of the coefficient of `wf` on the atomic sites
     """
@@ -48,8 +48,6 @@ class Wavefunction(GeometryPlot):
         if realspace:
             if 'shape' not in kwargs:
                 kwargs['shape'] = [100,100,1]
-            if 'z' not in kwargs:
-                raise ValueError('z coordinate needs to be passed to slice the real space grid')
 
             if 'vmin' not in kwargs:
                 kwargs['vmin'] = 0
@@ -60,7 +58,7 @@ class Wavefunction(GeometryPlot):
                 if 'z' in kwargs:
                     origin = [xmin, ymin, -kwargs['z']]
                 else:
-                    origin = [xmin, ymin, np.amin(HH.geometry.xyz[:,2])]
+                    raise ValueError('Either a SC or the z coordinate to slice the real space grid needs to be passed')
 
                 kwargs['sc'] = sisl.SuperCell([xmax-xmin, ymax-ymin, 1000], origin=origin)
 

--- a/hubbard/plot/wavefunction.py
+++ b/hubbard/plot/wavefunction.py
@@ -23,6 +23,7 @@ class Wavefunction(GeometryPlot):
     Notes
     -----
     If `realspace` kwarg is passed it plots the wavefunction in a realspace grid
+    In this case the `z` kwarg needs to be passed to slice the real space grid at the desired z coordinate
     In other case the wavefunction is plotted as a scatter plot, where the size of the blobs depend on the value
     of the coefficient of `wf` on the atomic sites
     """
@@ -45,18 +46,22 @@ class Wavefunction(GeometryPlot):
 
     def plot_wf(self, HH, wf, cb_label=r'Phase', realspace=False, **kwargs):
         if realspace:
-            if 'grid_unit' not in kwargs:
-                kwargs['grid_unit'] = [100,100,1]
+            if 'shape' not in kwargs:
+                kwargs['shape'] = [100,100,1]
             if 'z' not in kwargs:
-                kwargs['z'] = 1.1
+                raise ValueError('z coordinate needs to be passed to slice the real space grid')
 
             if 'vmin' not in kwargs:
                 kwargs['vmin'] = 0
 
             xmin, xmax, ymin, ymax = self.xmin, self.xmax, self.ymin, self.ymax
 
-            grid = real_space_grid(self.geometry, wf, kwargs['grid_unit'], xmin, xmax, ymin, ymax, z=kwargs['z'], mode='wavefunction')
-            self.__realspace__(grid, **kwargs)
+            grid = real_space_grid(self.geometry, wf, kwargs['shape'], xmin, xmax, ymin, ymax, kwargs['z'], mode='wavefunction')
+
+            # Slice it to obtain a 2D grid
+            slice_grid = grid.grid[:, :, 0].T.real
+
+            self.__realspace__(slice_grid, **kwargs)
 
             # Create custom map to differenciate it from polarization cmap
             import matplotlib.colors as mcolors

--- a/tests/test-hubbard-plots.py
+++ b/tests/test-hubbard-plots.py
@@ -56,14 +56,15 @@ if True:
     p = plot.LDOS_from_eigenstate(H, evec[:, 10], z=5, vmax=2e-15, realspace=True, ext_geom=molecule, colorbar=True)
     p.savefig('ldos_rs.pdf')
 
-    p = plot.Charge(H, realspace=True, ext_geom=molecule, z=5, vmax=1e-4, vmin=-1e-4, colorbar=True)
+    p = plot.Charge(H, realspace=True, ext_geom=molecule, z=5, vmax=5e-14, vmin=0, colorbar=True)
+    p.imshow.set_cmap('Reds')
     p.savefig('chg_rs.pdf')
 
-    p = plot.ChargeDifference(H, ext_geom=molecule, realspace=True, z=5, vmax=3e-5, vmin=-3e-5, colorbar=True)
+    p = plot.ChargeDifference(H, ext_geom=molecule, realspace=True, z=5, vmax=3e-14, vmin=-3e-14, colorbar=True)
     p.savefig('chgdiff_rs.pdf')
 
-    p = plot.SpinPolarization(H, ext_geom=molecule, realspace=True, z=5, vmax=3e-5, vmin=-3e-5, colorbar=True)
+    p = plot.SpinPolarization(H, ext_geom=molecule, realspace=True, z=5, vmax=7e-15, vmin=-7e-15, colorbar=True)
     p.savefig('pol_rs.pdf')
 
-    p = plot.Wavefunction(H, evec[:, 10], ext_geom=molecule, realspace=True, z=5, vmax=1.5e-3, vmin=-1.5e-3, colorbar=True)
+    p = plot.Wavefunction(H, evec[:, 10], ext_geom=molecule, realspace=True, z=5, vmax=5e-8, vmin=-5e-8, colorbar=True, bdx=3)
     p.savefig('wf_rs.pdf')

--- a/tests/test-hubbard-plots.py
+++ b/tests/test-hubbard-plots.py
@@ -29,6 +29,7 @@ p = plot.SpinPolarization(H, ext_geom=molecule, colorbar=True, vmax=0.2)
 p.annotate()
 p.savefig('pol.pdf')
 
+H.H.shift(-H.find_midgap())
 ev, evec = H.eigh(eigvals_only=False, spin=0)
 p = plot.Wavefunction(H, 500 * evec[:, 10], ext_geom=molecule, colorbar=True)
 p.savefig('wf.pdf')
@@ -39,21 +40,20 @@ p.savefig('spectrum.pdf')
 p = plot.LDOSmap(H)
 p.savefig('ldos_map.pdf')
 
-H.H.shift(-H.find_midgap())
 p = plot.DOS(H, np.linspace(-0.2, 0.2, 101))
 p.savefig('total_dos.pdf')
 
 p = plot.DOS(H, np.linspace(-0.2, 0.2, 101), sites=[60])
 p.savefig('ldos.pdf')
 
-DOS = H.PDOS(ev[int(H.q[0]) - 1], eta=1e-2, spin=[0])
-p = plot.DOS_distribution(H, DOS * 300, sites=[60], ext_geom=molecule)
+DOS = H.PDOS(ev[10], eta=1e-3, spin=[0])
+p = plot.DOS_distribution(H, DOS * 100, sites=[60], ext_geom=molecule)
 p.savefig('pdos.pdf')
 
 # Test real-space plots?
 if True:
 
-    p = plot.DOS_distribution(H, DOS, z=7, realspace=True, ext_geom=molecule, colorbar=True)
+    p = plot.DOS_distribution(H, evec[:, 10], z=5, vmax=2e-15, realspace=True, ext_geom=molecule, colorbar=True)
     p.savefig('pdos_rs.pdf')
 
     p = plot.Charge(H, realspace=True, ext_geom=molecule, vmax=1e-4, vmin=-1e-4, colorbar=True)

--- a/tests/test-hubbard-plots.py
+++ b/tests/test-hubbard-plots.py
@@ -31,6 +31,7 @@ p.savefig('pol.pdf')
 
 H.H.shift(-H.find_midgap())
 ev, evec = H.eigh(eigvals_only=False, spin=0)
+
 p = plot.Wavefunction(H, 500 * evec[:, 10], ext_geom=molecule, colorbar=True)
 p.savefig('wf.pdf')
 
@@ -46,23 +47,23 @@ p.savefig('total_dos.pdf')
 p = plot.PDOS(H, np.linspace(-0.2, 0.2, 101), sites=[60])
 p.savefig('pdos_energy_resolved.pdf')
 
-p = plot.EigenLDOS(H, evec[:, 10] * 200, sites=[60], ext_geom=molecule)
+p = plot.LDOS_from_eigenstate(H, evec[:, 10] * 200, sites=[60], ext_geom=molecule)
 p.savefig('pdos.pdf')
 
 # Test real-space plots?
 if True:
 
-    p = plot.EigenLDOS(H, evec[:, 10], z=5, vmax=2e-15, realspace=True, ext_geom=molecule, colorbar=True)
+    p = plot.LDOS_from_eigenstate(H, evec[:, 10], z=5, vmax=2e-15, realspace=True, ext_geom=molecule, colorbar=True)
     p.savefig('ldos_rs.pdf')
 
-    p = plot.Charge(H, realspace=True, ext_geom=molecule, vmax=1e-4, vmin=-1e-4, colorbar=True)
+    p = plot.Charge(H, realspace=True, ext_geom=molecule, z=5, vmax=1e-4, vmin=-1e-4, colorbar=True)
     p.savefig('chg_rs.pdf')
 
-    p = plot.ChargeDifference(H, ext_geom=molecule, realspace=True, vmax=3e-5, vmin=-3e-5, colorbar=True)
+    p = plot.ChargeDifference(H, ext_geom=molecule, realspace=True, z=5, vmax=3e-5, vmin=-3e-5, colorbar=True)
     p.savefig('chgdiff_rs.pdf')
 
-    p = plot.SpinPolarization(H, ext_geom=molecule, realspace=True, vmax=3e-5, vmin=-3e-5, colorbar=True)
+    p = plot.SpinPolarization(H, ext_geom=molecule, realspace=True, z=5, vmax=3e-5, vmin=-3e-5, colorbar=True)
     p.savefig('pol_rs.pdf')
 
-    p = plot.Wavefunction(H, evec[:, 10], ext_geom=molecule, realspace=True, vmax=1.5e-3, vmin=-1.5e-3, colorbar=True)
+    p = plot.Wavefunction(H, evec[:, 10], ext_geom=molecule, realspace=True, z=5, vmax=1.5e-3, vmin=-1.5e-3, colorbar=True)
     p.savefig('wf_rs.pdf')

--- a/tests/test-hubbard-plots.py
+++ b/tests/test-hubbard-plots.py
@@ -37,24 +37,23 @@ p.savefig('wf.pdf')
 p = plot.Spectrum(H)
 p.savefig('spectrum.pdf')
 
-p = plot.LDOSmap(H)
-p.savefig('ldos_map.pdf')
+p = plot.DOSmap(H)
+p.savefig('2Ddos_map.pdf')
 
-p = plot.DOS(H, np.linspace(-0.2, 0.2, 101))
+p = plot.PDOS(H, np.linspace(-0.2, 0.2, 101))
 p.savefig('total_dos.pdf')
 
-p = plot.DOS(H, np.linspace(-0.2, 0.2, 101), sites=[60])
-p.savefig('ldos.pdf')
+p = plot.PDOS(H, np.linspace(-0.2, 0.2, 101), sites=[60])
+p.savefig('pdos_energy_resolved.pdf')
 
-DOS = H.PDOS(ev[10], eta=1e-3, spin=[0])
-p = plot.DOS_distribution(H, DOS * 100, sites=[60], ext_geom=molecule)
+p = plot.EigenLDOS(H, evec[:, 10] * 200, sites=[60], ext_geom=molecule)
 p.savefig('pdos.pdf')
 
 # Test real-space plots?
 if True:
 
-    p = plot.DOS_distribution(H, evec[:, 10], z=5, vmax=2e-15, realspace=True, ext_geom=molecule, colorbar=True)
-    p.savefig('pdos_rs.pdf')
+    p = plot.EigenLDOS(H, evec[:, 10], z=5, vmax=2e-15, realspace=True, ext_geom=molecule, colorbar=True)
+    p.savefig('ldos_rs.pdf')
 
     p = plot.Charge(H, realspace=True, ext_geom=molecule, vmax=1e-4, vmin=-1e-4, colorbar=True)
     p.savefig('chg_rs.pdf')

--- a/tests/test-hubbard-quantitative.py
+++ b/tests/test-hubbard-quantitative.py
@@ -62,7 +62,7 @@ if True:
     egrid = np.linspace(-1, 1, 50)
     import hubbard.plot as plot
     H.H.shift(-H.fermi_level())
-    p = plot.DOS(H, egrid, eta=1e-2, spin=0)
+    p = plot.PDOS(H, egrid, eta=1e-2, spin=0)
 
     # Now compute same molecule with the WBL approximation with gamma=0
     from hubbard.negf import NEGF


### PR DESCRIPTION
Previously we were expanding the PDOS on a grid as if it was a charge density (using `sisl.DensityMatrix` to expand the PDOS on the realspace grid)  but this was incorrect. With this fix now `sisl.Wavefunction` is used to expand the wavefunction on the grid and then we square the grid to the power of 2 to obtain the PDOS resolved in realspace.
