### PR TITLE
mnt: updated sisl dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Before installation of __hubbard__ the following packages are required
    - scipy >= 0.18
    - netCDF4 >= 1.3.1
    - matplotlib >= 2.2.2
-   - [sisl][sisl] >= 0.11.0
+   - [sisl][sisl] >= 0.12.1
 
 
 ## Installation ##

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -12,7 +12,7 @@ Required dependencies
 
    * SciPy_ 0.18 or newer
 
-   * sisl_ 0.11.0 or newer
+   * sisl_ 0.12.1 or newer
 
 Optional:
 
@@ -21,7 +21,7 @@ Optional:
 .. _Python: https://www.python.org/
 .. _NumPy: https://docs.scipy.org/doc/numpy/reference/
 .. _SciPy: https://docs.scipy.org/doc/scipy/reference/
-.. _sisl : https://sisl.readthedocs.io/en/latest/installation.html
+.. _sisl : https://zerothi.github.io/sisl
 .. _Matplotlib: https://matplotlib.org/
 
 

--- a/docs/publications.rst
+++ b/docs/publications.rst
@@ -36,7 +36,7 @@ publications below.
 Citing the hubbard package
 ==========================
 
-If hubbard is used to produce scientific contributions please include citations, in addition to `sisl <https://sisl.readthedocs.io/en/latest/cite.html>`_, to the following Zenodo DOI:
+If hubbard is used to produce scientific contributions please include citations, in addition to `sisl <https://zerothi.github.io/sisl/cite.html>`_, to the following Zenodo DOI:
 
 .. code-block:: bash
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ requires-python = ">=3.6"
 # This ensures that hubbard should not worry about
 # dependencies
 dependencies = [
-    "sisl>=0.11.0",
+    "sisl>=0.12.1",
     "matplotlib>=2.2.2"
 ]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,10 @@
+[metadata]
+name = hubbard
+version = attr: hubbard.__version__
+license = LGPL-3.0
+readme = file: README.md
+long_description = file: README.md
+long_description_content_type = text/markdown
+project_urls =
+   Homepage = https://dipc-cc.github.io/hubbard
+   Documentation = https://dipc-cc.github.io/hubbard


### PR DESCRIPTION
Updated sisl version dependency, I seem to recall some functionality that you contributed was used immediately?

Also added `setup.cfg` which is necessary if you want to release on pypi. It seemed somewhat related so I thought it was ok to do it once.