### PR TITLE
More general plot class for arbitrary geometry, not only sp2

### DIFF
--- a/hubbard/plot/bonds.py
+++ b/hubbard/plot/bonds.py
@@ -17,16 +17,16 @@ class BondOrder(GeometryPlot):
         Mean-field Hubbard Hamiltonian
     """
 
-    def __init__(self, HH, selection=None, **kwargs):
+    def __init__(self, HH, selection=None, collection='sp2', **kwargs):
 
         if 'cmap' not in kwargs:
             kwargs['cmap'] = plt.cm.bwr
 
         if selection is None:
-            super().__init__(HH.geometry, **kwargs)
+            super().__init__(HH.geometry, collection=collection, **kwargs)
         else:
             print("doing sub")
-            super().__init__(HH.geometry.sub(selection), **kwargs)
+            super().__init__(HH.geometry.sub(selection), collection=collection, **kwargs)
 
         bbox_props = dict(boxstyle="round", fc="w", ec="0.5", alpha=0.9)
 

--- a/hubbard/plot/charge.py
+++ b/hubbard/plot/charge.py
@@ -31,7 +31,7 @@ class Charge(GeometryPlot):
 
     """
 
-    def __init__(self, HH, ext_geom=None, spin=[0, 1], realspace=False, **kwargs):
+    def __init__(self, HH, ext_geom=None, collection='sp2', bdx=2, spin=[0, 1], realspace=False, **kwargs):
         # Set default kwargs
         if realspace:
             if 'facecolor' not in kwargs:
@@ -46,7 +46,7 @@ class Charge(GeometryPlot):
             if 'label' not in kwargs:
                 kwargs['label']=r'$Q_\uparrow+Q_\downarrow$ ($e$)'
 
-        super().__init__(HH.geometry, ext_geom=ext_geom, **kwargs)
+        super().__init__(HH.geometry, ext_geom=ext_geom, collection=collection, bdx=bdx, **kwargs)
 
         # Compute total charge on each site
         if not isinstance(spin, list):
@@ -107,7 +107,7 @@ class ChargeDifference(GeometryPlot):
         If True either a `sisl.SuperCell` (`sc` kwarg) or the `z` kwarg to slice the real space grid at the desired z coordinate needs to be passed
     """
 
-    def __init__(self, HH, ext_geom=None, realspace=False, **kwargs):
+    def __init__(self, HH, ext_geom=None, collection='sp2', bdx=2, realspace=False, **kwargs):
 
         # Set default kwargs
         if realspace:
@@ -123,7 +123,7 @@ class ChargeDifference(GeometryPlot):
             if 'label' not in kwargs:
                 kwargs['label']=r'$Q_\uparrow+Q_\downarrow-Q_\mathrm{NA}$ ($e$)'
 
-        super().__init__(HH.geometry, ext_geom=ext_geom, **kwargs)
+        super().__init__(HH.geometry, ext_geom=ext_geom, collection=collection, bdx=bdx, **kwargs)
 
         # Compute total charge on each site, subtract neutral atom charge
         chg = np.zeros((HH.geometry.na))
@@ -186,7 +186,7 @@ class SpinPolarization(GeometryPlot):
         If True either a `sisl.SuperCell` (`sc` kwarg) or the `z` kwarg to slice the real space grid at the desired z coordinate needs to be passed
     """
 
-    def __init__(self, HH, ext_geom=None, realspace=False, **kwargs):
+    def __init__(self, HH, ext_geom=None, collection='sp2', bdx=2, realspace=False, **kwargs):
 
         # Set default kwargs
         if realspace:
@@ -202,7 +202,7 @@ class SpinPolarization(GeometryPlot):
             if 'label' not in kwargs:
                 kwargs['label']=r'$Q_\uparrow-Q_\downarrow$ ($e$)'
 
-        super().__init__(HH.geometry, ext_geom=ext_geom, **kwargs)
+        super().__init__(HH.geometry, ext_geom=ext_geom,  collection=collection, bdx=bdx, **kwargs)
 
         # Sum over all orbitals
         chg = np.zeros((HH.geometry.na))

--- a/hubbard/plot/spectrum.py
+++ b/hubbard/plot/spectrum.py
@@ -170,7 +170,7 @@ class LDOS_from_eigenstate(GeometryPlot):
         In this case either a `sisl.SuperCell` (`sc` kwarg) or the `z` kwarg to slice the real space grid at the desired z coordinate needs to be passed
     """
 
-    def __init__(self, HH, wavefunction, sites=[], ext_geom=None, realspace=False, **kwargs):
+    def __init__(self, HH, wavefunction, sites=[], ext_geom=None, realspace=False, collection='sp2', **kwargs):
 
         # Set default kwargs
         if realspace:
@@ -182,7 +182,7 @@ class LDOS_from_eigenstate(GeometryPlot):
             if 'cmap' not in kwargs:
                 kwargs['cmap'] = plt.cm.bwr
 
-        super().__init__(HH.geometry, ext_geom=ext_geom, **kwargs)
+        super().__init__(HH.geometry, ext_geom=ext_geom, collection=collection, **kwargs)
 
         x = HH.geometry[:, 0]
         y = HH.geometry[:, 1]
@@ -262,7 +262,7 @@ class LDOS(GeometryPlot):
     sisl.physics.electron.PDOS: sisl method to obtain PDOS
     """
 
-    def __init__(self, HH, E, sites=[], spin=[0,1], ext_geom=None, realspace=False, eta=1e-3, distribution='lorentzian', **kwargs):
+    def __init__(self, HH, E, sites=[], spin=[0,1], ext_geom=None, realspace=False, eta=1e-3, distribution='lorentzian', collection='sp2', **kwargs):
 
         # Set default kwargs
         if realspace:
@@ -274,7 +274,7 @@ class LDOS(GeometryPlot):
             if 'cmap' not in kwargs:
                 kwargs['cmap'] = plt.cm.bwr
 
-        super().__init__(HH.geometry, ext_geom=ext_geom, **kwargs)
+        super().__init__(HH.geometry, ext_geom=ext_geom, collection=collection, **kwargs)
 
         x = HH.geometry[:, 0]
         y = HH.geometry[:, 1]

--- a/hubbard/plot/wavefunction.py
+++ b/hubbard/plot/wavefunction.py
@@ -28,7 +28,7 @@ class Wavefunction(GeometryPlot):
     of the coefficient of `wf` on the atomic sites
     """
 
-    def __init__(self, HH, wf, ext_geom=None, cb_label=r'Phase', realspace=False, **kwargs):
+    def __init__(self, HH, wf, ext_geom=None, cb_label=r'Phase', realspace=False, collection='sp2', **kwargs):
 
         # Set default kwargs
         if realspace:
@@ -40,7 +40,7 @@ class Wavefunction(GeometryPlot):
             if 'cmap' not in kwargs:
                 kwargs['cmap'] = plt.cm.bwr
 
-        super().__init__(HH.geometry, ext_geom=ext_geom, **kwargs)
+        super().__init__(HH.geometry, ext_geom=ext_geom, collection=collection, **kwargs)
 
         self.plot_wf(HH, wf, cb_label=cb_label, realspace=realspace, **kwargs)
 


### PR DESCRIPTION
The way in which we plotted geometry-related plots was specific for sp2 carbon systems, however we can easily generalize this for now by allowing to pass any other patch collection that the user may want to use.

It is still default to the sp2 case to minimize the changes, but maybe it should be established the `None` case as the default value?