### PR TITLE
Some fixes in IO

### DIFF
--- a/hubbard/hamiltonian.py
+++ b/hubbard/hamiltonian.py
@@ -455,7 +455,7 @@ class HubbardHamiltonian(object):
                 self.n = fh.read_density()[0]
             self.update_hamiltonian()
 
-    def write_density(self, fn, mode='w', group=None):
+    def write_density(self, fn, mode='a', group=None):
         """ Write density in a binary file
 
         Parameters

--- a/hubbard/hamiltonian.py
+++ b/hubbard/hamiltonian.py
@@ -456,7 +456,7 @@ class HubbardHamiltonian(object):
             fh.close()
             self.update_hamiltonian()
 
-    def write_density(self, fn, mode='a', group=None):
+    def write_density(self, fn, mode='w', group=None):
         """ Write density in a binary file
 
         Parameters
@@ -471,7 +471,7 @@ class HubbardHamiltonian(object):
         if not os.path.isfile(fn):
             mode = 'w'
         fh = nc.ncSileHubbard(fn, mode=mode)
-        fh.write_density(self.n, self.U, self.kT, self.units, group)
+        fh.write_density(self.n, self.U, self.kT, self.units, Uij=self.Uij, group=group)
         fh.close()
 
     def write_initspin(self, fn, ext_geom=None, spinfix=True, mode='a', eps=0.1):

--- a/hubbard/hamiltonian.py
+++ b/hubbard/hamiltonian.py
@@ -453,7 +453,6 @@ class HubbardHamiltonian(object):
                 warnings.warn(f'Groups found in {fn}, using the density from the first one')
                 # Read only the first element from the list
                 self.n = fh.read_density()[0]
-            fh.close()
             self.update_hamiltonian()
 
     def write_density(self, fn, mode='w', group=None):
@@ -472,7 +471,6 @@ class HubbardHamiltonian(object):
             mode = 'w'
         fh = nc.ncSileHubbard(fn, mode=mode)
         fh.write_density(self.n, self.U, self.kT, self.units, Uij=self.Uij, group=group)
-        fh.close()
 
     def write_initspin(self, fn, ext_geom=None, spinfix=True, mode='a', eps=0.1):
         """ Write spin polarization to SIESTA fdf-block

--- a/hubbard/ncsile.py
+++ b/hubbard/ncsile.py
@@ -115,7 +115,7 @@ class ncSileHubbard(sisl.SileCDF):
                         n.append(_n)
         return n
 
-    def write_density(self, n, U, kT, units, group=None):
+    def write_density(self, n, U, kT, units, Uij=None, group=None):
         # Create group
         if group is not None:
             g = self._crt_grp(self, group)
@@ -126,15 +126,30 @@ class ncSileHubbard(sisl.SileCDF):
         self._crt_dim(self, 'nspin', n.shape[0])
         self._crt_dim(self, 'norb', n.shape[1])
 
-        # Write variable n
+        # Write variable
         v1 = self._crt_var(g, 'n', ('f8', 'f8'), ('nspin', 'norb'))
-        v2 = self._crt_var(g, 'U', ('f8', 'f8'), ('norb', 'norb'))
+
+        if isinstance(U, np.ndarray):
+            self._crt_dim(self, 'nU', len(U))
+            v2 = self._crt_var(g, 'U', ('f8'), ('nU'))
+        elif type(U) in (float, int):
+            v2 = self._crt_var(g, 'U', 'f8')
+
         v3 = self._crt_var(g, 'kT', 'f8')
+
         v1.info = 'Spin densities'
         v2.info = 'Coulomb repulsion parameter in ' + units
         v3.info = 'Temperature of the system in '+ units
         v1[:] = n
         v2[:] = U
         v3[:] = kT
+
+        if Uij:
+            self._crt_dim(self, 'Uij0', Uij.shape[0])
+            self._crt_dim(self, 'Uij1', Uij.shape[2])
+
+            v4 = self._crt_var(g, 'Uij', ('f8', 'f8'), ('Uij0', 'Uij1'))
+            v4.info = 'Off diagonal Coulomb repulsion elements in' + units
+            v4[:] = Uij
 
 sisl.io.add_sile("HU.nc", ncSileHubbard, gzip=False)

--- a/hubbard/ncsile.py
+++ b/hubbard/ncsile.py
@@ -11,17 +11,19 @@ class ncSileHubbard(sisl.SileCDF):
     --------
     sisl.io.SileCDF : sisl class
     """
-    def read_U(self, group=None):
+    def read_U(self, group=None, index=0):
         """ Read Coulomb repulsion U parameter from netcdf file
 
         Parameters
         ----------
         group: str, optional
-            netcdf group
+           netcdf group
+        index: int or list of ints, optional
+            If there are groups in the file and no group is specified then it reads the U parameter from the index item in the groups dictionary
 
         Returns
         -------
-        Float or list of floats containing the temperature for each netcdf group
+        Float, numpy.ndarray or list depending on the saved U and if `index` is a list
         """
         # Find group
         if group is not None:
@@ -35,27 +37,35 @@ class ncSileHubbard(sisl.SileCDF):
             try:
                 U = np.array(self.variables['U'][:])
             except:
-                # Read from all groups, append all U
                 if self.groups:
-                    U  = []
-                    for k in self.groups:
+
+                    k = list(self.groups.keys())[index]
+
+                    if isinstance(k,list):
+                        U  = []
+                        for i in k:
+                            g = self.groups[i]
+                            # Read U from selcted groups and append them in a list
+                            _U = np.array(g.variables['U'][:])
+                            U.append(_U)
+                    else:
                         g = self.groups[k]
-                        # Read U from all groups and append them in a list
-                        _U = np.array(g.variables['U'][:])
-                        U.append(_U)
+                        U = np.array(g.variables['U'][:])
         return U
 
-    def read_kT(self, group=None):
+    def read_kT(self, group=None, index=0):
         """ Read temperature from netcdf file
 
         Parameters
         ----------
         group: str, optional
-            netcdf group
+           netcdf group
+        index: int or list of ints, optional
+            If there are groups in the file and no group is specified then it reads the temperature (kT) from the index item in the groups dictionary
 
         Returns
         -------
-        Float or list of floats containing the temperature times the Boltzmann constant (k) for each netcdf group
+        Float or list of floats containing the temperature times the Boltzmann constant (k)
         """
         # Find group
         if group is not None:
@@ -70,27 +80,36 @@ class ncSileHubbard(sisl.SileCDF):
             try:
                 kT = np.array(self.variables['kT'][:])
             except:
-                # Read from all groups, append all kT
                 if self.groups:
-                    kT  = []
-                    for k in self.groups:
+
+                    k = list(self.groups.keys())[index]
+
+                    if isinstance(k,list):
+                        kT  = []
+                        for i in k:
+                            g = self.groups[i]
+                            # Read U from selected groups and append them in a list
+                            _kT = np.array(g.variables['kT'][:])
+                            kT.append(_kT)
+                    else:
                         g = self.groups[k]
-                        # Read kT from all groups and append them in a list
-                        _kT = np.array(g.variables['kT'][:])
-                        kT.append(_kT)
+                        kT = np.array(g.variables['kT'][:])
         return kT
 
-    def read_density(self, group=None):
+    def read_density(self, group=None, index=0):
         """ Read density from netcdf file
 
         Parameters
         ----------
         group: str, optional
-           netcdf group. If there are groups in the file and no group is found then it reads the n variable from all groups found
+           netcdf group
+        index: int or list of ints, optional
+            If there are groups in the file and no group is specified then it reads the n variable (density) from the index item in the groups dictionary
+
 
         Returns
         -------
-        numpy.ndarray or list of numpy.ndarrays
+        numpy.ndarray or list of numpy.ndarrays, depending if `index` is a list
 
         """
         # Find group
@@ -105,14 +124,19 @@ class ncSileHubbard(sisl.SileCDF):
             try:
                 n = np.array(self.variables['n'][:])
             except:
-                # Read from all groups, append all densities
                 if self.groups:
-                    n  = []
-                    for k in self.groups:
+                    k = list(self.groups.keys())[index]
+
+                    if isinstance(k,list):
+                        n  = []
+                        for i in k:
+                            g = self.groups[i]
+                            # Read U from selected groups and append them in a list
+                            _n = np.array(g.variables['n'][:])
+                            n.append(_n)
+                    else:
                         g = self.groups[k]
-                        # Read densities from all groups and append them in a list
-                        _n = np.array(g.variables['n'][:])
-                        n.append(_n)
+                        n = np.array(g.variables['n'][:])
         return n
 
     def write_density(self, n, U, kT, units, Uij=None, group=None):

--- a/hubbard/ncsile.py
+++ b/hubbard/ncsile.py
@@ -156,7 +156,7 @@ class ncSileHubbard(sisl.SileCDF):
         if isinstance(U, np.ndarray):
             self._crt_dim(self, 'nU', len(U))
             v2 = self._crt_var(g, 'U', ('f8'), ('nU'))
-        elif type(U) in (float, int):
+        elif isinstance(U, (float, int)):
             v2 = self._crt_var(g, 'U', 'f8')
 
         v3 = self._crt_var(g, 'kT', 'f8')
@@ -168,9 +168,9 @@ class ncSileHubbard(sisl.SileCDF):
         v2[:] = U
         v3[:] = kT
 
-        if Uij:
+        if Uij is not None:
             self._crt_dim(self, 'Uij0', Uij.shape[0])
-            self._crt_dim(self, 'Uij1', Uij.shape[2])
+            self._crt_dim(self, 'Uij1', Uij.shape[1])
 
             v4 = self._crt_var(g, 'Uij', ('f8', 'f8'), ('Uij0', 'Uij1'))
             v4.info = 'Off diagonal Coulomb repulsion elements in' + units

--- a/hubbard/ncsile.py
+++ b/hubbard/ncsile.py
@@ -154,8 +154,7 @@ class ncSileHubbard(sisl.SileCDF):
         v1 = self._crt_var(g, 'n', ('f8', 'f8'), ('nspin', 'norb'))
 
         if isinstance(U, np.ndarray):
-            self._crt_dim(self, 'nU', len(U))
-            v2 = self._crt_var(g, 'U', ('f8'), ('nU'))
+            v2 = self._crt_var(g, 'U', ('f8'), ('norb'))
         elif isinstance(U, (float, int)):
             v2 = self._crt_var(g, 'U', 'f8')
 
@@ -169,10 +168,8 @@ class ncSileHubbard(sisl.SileCDF):
         v3[:] = kT
 
         if Uij is not None:
-            self._crt_dim(self, 'Uij0', Uij.shape[0])
-            self._crt_dim(self, 'Uij1', Uij.shape[1])
 
-            v4 = self._crt_var(g, 'Uij', ('f8', 'f8'), ('Uij0', 'Uij1'))
+            v4 = self._crt_var(g, 'Uij', ('f8', 'f8'), ('norb', 'norb'))
             v4.info = 'Off diagonal Coulomb repulsion elements in' + units
             v4[:] = Uij
 

--- a/tests/test-hubbard-io.py
+++ b/tests/test-hubbard-io.py
@@ -8,21 +8,21 @@ molecule.sc.set_nsc([1, 1, 1])
 
 # Build HubbardHamiltonian object
 Hsp2 = sp2(molecule)
-H = HubbardHamiltonian(Hsp2, U=3.5)
+H = HubbardHamiltonian(Hsp2, U=3.5, Uij=np.ones((Hsp2.no, Hsp2.no)))
 # Generate simple density
 H.n = np.ones((2, H.sites))*0.5
 
-print(f'1. Write and read densities under group {H.get_hash()} using the HubbardHamiltonian class\n')
+print(f'1. Write and read densities under group U{H.U:.1f} using the HubbardHamiltonian class\n')
 # Write density in file
-H.write_density('mol-ref/test.HU.nc', group=H.get_hash(), mode='w')
+H.write_density('mol-ref/test.HU.nc', group=f'U{H.U:.1f}', mode='w')
 # Read density using the HubbardHamiltonian class
-H.read_density('mol-ref/test.HU.nc', group=H.get_hash())
+H.read_density('mol-ref/test.HU.nc', group=f'U{H.U:.1f}')
 
 # Write another density in file under another group
-print(f'2. Write another densities under another group\n')
 H.n *= 2
-H.write_density('mol-ref/test.HU.nc', group='group2', mode='a')
-
+H.U *= 2
+print(f'2. Write another densities under group U{H.U:.1f}\n')
+H.write_density('mol-ref/test.HU.nc', group=f'U{H.U:.1f}', mode='a')
 
 print('3. Read density, U and kT using ncsile from all groups')
 fh = sisl.get_sile('mol-ref/test.HU.nc', mode='r')
@@ -34,7 +34,7 @@ for g in fh.groups:
     print('\n')
 
 print('4. Read using HubbardHamiltoninan class')
-# Read density using the HubbardHamiltonian class
+# Read density using the HubbardHamiltonian class with no group specified. It reads from the first one saved
 H.read_density('mol-ref/test.HU.nc', group=None)
 print('H.n:', H.n)
 

--- a/tests/test-hubbard-multi-orbitals.py
+++ b/tests/test-hubbard-multi-orbitals.py
@@ -61,6 +61,9 @@ HH = HubbardHamiltonian(TBham, U=None, nkpt=[100,1,1])
 HH.set_polarization([0], dn=[g.a2o(13)])
 HH.converge(density.calc_n, print_info=True, tol=1e-10, steps=3)
 
+print('\n Write densities in multi-orbital-density.nc')
+HH.write_density('multi-orbital-density.nc')
+
 # Print spin-densities difference compared to sing-orbital case
 print('\n   ** Difference between spin densities for single and multi-orbital cases **')
 print(HH.n[:,idx]-n_single)


### PR DESCRIPTION
I think it was a little confusing that sometimes the reading methods returned a list of densities or the proper sized `numpy.array` for the densities (as an example). For this reason I think is more convenient to return the list of densities from all groups _only_ if specified.

Another option is to forget about the groups and just use mode='w' and not allow to append (mode='a') when writing variables in a file.

I also changed that  `U` is saved as its original `type` (float or array). Previously it was always saved as an array.
