### PR TITLE
minor: update charge when reading density from file

### DIFF
--- a/hubbard/hamiltonian.py
+++ b/hubbard/hamiltonian.py
@@ -454,10 +454,12 @@ class HubbardHamiltonian(object):
         if os.path.isfile(fn):
             fh = nc.ncSileHubbard(fn, mode=mode)
             self.n = fh.read_density(group=group)
+            self.q = self.n.sum(axis=1) # Update charge with read density
             if isinstance(self.n, list):
                 warnings.warn(f'Groups found in {fn}, using the density from the first one')
                 # Read only the first element from the list
                 self.n = fh.read_density()[0]
+                self.q = self.n.sum(axis=1) # Update charge with read density
             fh.close()
             self.update_hamiltonian()
 


### PR DESCRIPTION
In this PR the code updates the charge of the `HubbardHamiltonian` object (`q`) when reading the densities from file. Previously the charge was not updated, which led to problems when performing calculations for a charged system.