### PR TITLE
fix: use correct form of pz orbital

### DIFF
--- a/hubbard/sp2.py
+++ b/hubbard/sp2.py
@@ -5,7 +5,7 @@ __all__ = ['sp2']
 
 
 def sp2(ext_geom, t1=2.7, t2=0.2, t3=0.18, eB=3., eN=-3.,
-        s1=0, s2=0, s3=0, dq=0, spin=sisl.physics.Spin('polarized')):
+        s1=0, s2=0, s3=0, dq=0, spin=sisl.physics.Spin('polarized'), atoms=None):
     """ Function to create a Tight Binding Hamiltoninan for sp2 Carbon systems
 
     It takes advantage of the `sisl` class for building sparse Hamiltonian matrices,
@@ -19,6 +19,10 @@ def sp2(ext_geom, t1=2.7, t2=0.2, t3=0.18, eB=3., eN=-3.,
 
     The function will also take into account the possible presence of Boron or Nitrogen atoms,
     for which one would need to specify the on-site energy for those atoms (``eB`` and ``eN``)
+
+    If no atoms are passed it will assign to each sp2 atom a `pz` hydrogen-like orbital
+    (i.e., `sisl.HydrogenicOrbital` with effective nuclear charge `Zeff=3.2`).
+    This can be modified by the user with the argument ``atoms``
 
     Parameters
     ----------
@@ -45,6 +49,9 @@ def sp2(ext_geom, t1=2.7, t2=0.2, t3=0.18, eB=3., eN=-3.,
     spin: str or sisl.physics.Spin, optional
         to define a polarized or unpolarized system pass ``spin=polarized`` or ``spin=unpolarized``
         or the corresponding `sisl.physics.Spin` object
+    atoms: sisl.Atom or sisl.Atoms, optional
+        Atoms for the geometry containing orbital information. It can be a `sisl.Atoms` instance containing different `sisl.Atom` objects.
+        In this case it should contain all atoms of the sp2 geometry (i.e. `Z in [5,6,7]`)
 
     Returns
     -------
@@ -71,15 +78,21 @@ def sp2(ext_geom, t1=2.7, t2=0.2, t3=0.18, eB=3., eN=-3.,
     pi_geom.reduce()
 
     # Iterate over atomic species to set initial charge
-    maxR = 20
-    r = np.linspace(0, maxR, 700)
-    # In Slater-type orbitals (Hydrogen-like atom solution), the radial function is ~exp(-Zr/2a)
-    # where a=0.529 \AA is the Bohr radius and Z is the atomic number.
-    # We use the effective nuclear charge instead, which for Carbon atoms is approximately Zeff~3.
-    func =  np.exp(-3*r)
-    for atom, _ in pi_geom.atoms.iter(True):
-        pz = sisl.AtomicOrbital('pz', (r, func), R=maxR, q0=atom.Z-5+dq)
-        atom.orbitals[0] = pz
+    for atom, ia in pi_geom.atoms.iter(True):
+
+        # Check if there are orbitals saved in the geometry
+        if not all(isinstance(orb, (sisl.AtomicOrbital, sisl.HydrogenicOrbital)) for orb in atom.orbitals):
+            if atoms is None:
+                # Default atomic orbitals is pz orbitals
+                pz = sisl.HydrogenicOrbital(2, 1, 0, 3.2, q0=atom.Z-5+dq, R=10.)
+                pi_geom.atoms.replace_atom(atom, sisl.Atom(atom.Z, orbitals=pz))
+            else:
+                atoms = sisl.Atoms(atoms)
+                try:
+                    atom_ = list(filter(lambda x: (x.Z == atom.Z), atoms))[0]
+                except:
+                    raise ValueError(f'Atom with Z={atom.Z} not found')
+                pi_geom.atoms.replace_atom(atom, atom_)
 
     # Construct Hamiltonian
     if s1 != 0:

--- a/tests/test-hubbard-plots.py
+++ b/tests/test-hubbard-plots.py
@@ -53,18 +53,18 @@ p.savefig('pdos.pdf')
 # Test real-space plots?
 if True:
 
-    p = plot.LDOS_from_eigenstate(H, evec[:, 10], z=5, vmax=2e-15, realspace=True, ext_geom=molecule, colorbar=True, smooth={'r':0.6})
+    p = plot.LDOS_from_eigenstate(H, evec[:, 10], z=5, vmax=9e-12, realspace=True, ext_geom=molecule, colorbar=True, smooth={'r':0.6})
     p.savefig('ldos_rs.pdf')
 
-    p = plot.Charge(H, realspace=True, ext_geom=molecule, z=5, vmax=5e-14, vmin=0, colorbar=True)
+    p = plot.Charge(H, realspace=True, ext_geom=molecule, z=5, vmax=5e-10, vmin=0, colorbar=True)
     p.imshow.set_cmap('Reds')
     p.savefig('chg_rs.pdf')
 
-    p = plot.ChargeDifference(H, ext_geom=molecule, realspace=True, z=5, vmax=3e-14, vmin=-3e-14, colorbar=True)
+    p = plot.ChargeDifference(H, ext_geom=molecule, realspace=True, z=5, vmax=7e-11, vmin=-7e-11, colorbar=True)
     p.savefig('chgdiff_rs.pdf')
 
-    p = plot.SpinPolarization(H, ext_geom=molecule, realspace=True, z=5, vmax=7e-15, vmin=-7e-15, colorbar=True)
+    p = plot.SpinPolarization(H, ext_geom=molecule, realspace=True, z=5, vmax=7e-11, vmin=-7e-11, colorbar=True)
     p.savefig('pol_rs.pdf')
 
-    p = plot.Wavefunction(H, evec[:, 10], ext_geom=molecule, realspace=True, z=5, vmax=5e-8, vmin=-5e-8, colorbar=True, bdx=3)
+    p = plot.Wavefunction(H, evec[:, 10], ext_geom=molecule, realspace=True, z=5, vmax=5e-6, vmin=-5e-6, colorbar=True, bdx=3)
     p.savefig('wf_rs.pdf')


### PR DESCRIPTION
I think we were using the incorrect pz orbital for carbon atoms. With this fix we use `sisl.HydrogenicOrbital` instead.