### PR TITLE
Update for sisl version equal or newer than 0.15.0

### DIFF
--- a/hubbard/density.py
+++ b/hubbard/density.py
@@ -44,7 +44,7 @@ def calc_n(H, q):
 
         # Reduce to occupied stuff
         occ = es.occupation(dist[spin]) * weight
-        n = einsum('i,ij->j', occ, es.norm2(False).real)
+        n = einsum('i,ij->j', occ, es.norm2(projection='orbitals').real)
 
         Etot = es.eig.dot(occ)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ requires-python = ">=3.6"
 # This ensures that hubbard should not worry about
 # dependencies
 dependencies = [
-    "sisl>=0.12.1",
+    "sisl>=0.15.0",
     "matplotlib>=2.2.2"
 ]
 


### PR DESCRIPTION
`sisl.physics.electron.norm2` in `sisl >0.15.0`,  accepts the argument `projection` instead of `sum` (older versions). Since we use this method to obtain the density in `hubbard.density.calc_n` there was an error since it was using the default value for projection which was `"sum"` apparently.
In this PR we set this value to `projection=' atoms'` and now it works as before (by testing it with the usual test files). However, this only works for `sisl>=0.15.0`, so if we implement this change we must ensure that the users are using this version of `sisl`.