### PR TITLE
Update density.py

### DIFF
--- a/hubbard/density.py
+++ b/hubbard/density.py
@@ -40,12 +40,12 @@ def calc_n(H, q):
 
     # Solve eigenvalue problems
     def calc_occ(k, weight, spin):
-        n = np.empty_like(ni)
+        n = np.empty_like(ni[spin])
         es = H.eigenstate(k, spin=spin)
 
         # Reduce to occupied stuff
         occ = es.occupation(dist[spin]) * weight
-        n = einsum('i,ij->j', occ, es.norm2(False).real)
+        n = einsum('i,ij->j', occ, es.norm2(projection="atoms").real)
 
         Etot = es.eig.dot(occ)
 


### PR DESCRIPTION
The calc_n function had a minor bug in initializing the density. The local variable n inside calc_occ had the same dimensions as ni, but the local variable n is spin polarized. so it had one extra degree of freedom. I think this was causing unreliable behavior while plotting spin polarization for periodic structures.