### PR TITLE
Fix memory issue for density-to-grid

### DIFF
--- a/hubbard/grid.py
+++ b/hubbard/grid.py
@@ -48,7 +48,7 @@ def real_space_grid(geometry, lattice, vector, shape, mode='wavefunction', **kwa
         D = sisl.physics.DensityMatrix(g)
         a = np.arange(len(D))
         D.D[a, a] = vector
-        D.density(grid)
+        D.density(grid, method="direct")
 
     del g
     return grid


### PR DESCRIPTION
Was just running `test-hubbard-plots.py` and ran into a memory issue
```python
Traceback (most recent call last):
  File "/home/me/hubbard/tests/test-hubbard-plots.py", line 59, in <module>
    p = plot.Charge(H, realspace=True, ext_geom=molecule, z=5, vmax=5e-10, vmin=0, colorbar=True)
  File "/home/user/miniforge3/envs/hubbard-dev/lib/python3.14/site-packages/hubbard/plot/charge.py", line 80, in __init__
    grid = real_space_grid(self.geometry, kwargs['sc'], chg, kwargs['shape'], mode='charge')
  File "/home/me/miniforge3/envs/hubbard-dev/lib/python3.14/site-packages/hubbard/grid.py", line 54, in real_space_grid
    D.density(grid)
    ~~~~~~~~~^^^^^^
  File "/home/me/miniforge3/envs/hubbard-dev/lib/python3.14/site-packages/sisl/messages.py", line 107, in wrapped
    return func(*args, **kwargs)
  File "/home/me/miniforge3/envs/hubbard-dev/lib/python3.14/site-packages/sisl/physics/densitymatrix.py", line 201, in density
    psi_values = uc_dm.geometry._orbital_values(grid.shape)
  File "/home/me/miniforge3/envs/hubbard-dev/lib/python3.14/site-packages/sisl/_core/geometry.py", line 3824, in _orbital_values
    grid_values = np.zeros(max_vals, dtype=np.float64)
numpy._core._exceptions._ArrayMemoryError: Unable to allocate 416. GiB for an array with shape (55798749610,) and data type float64
```
Not exactly sure why, but adding `method="direct"` appears to fix this.