### PR TITLE
Replace `SuperCell` by `Lattice`

### DIFF
--- a/hubbard/__init__.py
+++ b/hubbard/__init__.py
@@ -34,8 +34,8 @@ Build the specific TB Hamiltonian for a sp2 system
 
    sp2
 
-Create real space grid for a geometry and supercell
-===================================================
+Create real space grid for a geometry and lattice
+=================================================
 
 .. autosummary::
    :toctree:

--- a/hubbard/grid.py
+++ b/hubbard/grid.py
@@ -3,7 +3,7 @@ import sisl
 
 
 def real_space_grid(geometry, lattice, vector, shape, mode='wavefunction', **kwargs):
-    """ Create real space `sisl.Grid` object for a `sisl.Geometry` and a `sisl.Supercell`
+    """ Create real space `sisl.Grid` object for a `sisl.Geometry` and a `sisl.Lattice`
 
     Parameters
     ----------

--- a/hubbard/plot/charge.py
+++ b/hubbard/plot/charge.py
@@ -27,7 +27,7 @@ class Charge(GeometryPlot):
         plot charge associated to one specific spin index, or both if ``spin=[0,1]``
     realspace: bool, optional
         if True it plots the total charge in a realspace grid. In other case it will be plotted as Mulliken populations
-        If True either a `sisl.SuperCell` (`sc` kwarg) or the `z` kwarg to slice the real space grid at the desired z coordinate needs to be passed
+        If True either a `sisl.Lattice` (`sc` kwarg) or the `z` kwarg to slice the real space grid at the desired z coordinate needs to be passed
 
     """
 
@@ -72,7 +72,7 @@ class Charge(GeometryPlot):
                 else:
                     raise ValueError('Either a SC or the z coordinate to slice the real space grid needs to be passed')
 
-                kwargs['sc'] = sisl.SuperCell([xmax-xmin, ymax-ymin, 1000], origin=origin)
+                kwargs['sc'] = sisl.Lattice([xmax-xmin, ymax-ymin, 1000], origin=origin)
 
             if 'axis' not in kwargs:
                 kwargs['axis'] = 2
@@ -104,7 +104,7 @@ class ChargeDifference(GeometryPlot):
         otherwise it only uses the geometry associated to the `hubbard.HubbardHamiltonian` (carbon backbone)
     realspace: bool, optional
         if True it plots the charge difference in a realspace grid. In other case it will be plotted as Mulliken populations
-        If True either a `sisl.SuperCell` (`sc` kwarg) or the `z` kwarg to slice the real space grid at the desired z coordinate needs to be passed
+        If True either a `sisl.Lattice` (`sc` kwarg) or the `z` kwarg to slice the real space grid at the desired z coordinate needs to be passed
     """
 
     def __init__(self, HH, ext_geom=None, realspace=False, **kwargs):
@@ -149,7 +149,7 @@ class ChargeDifference(GeometryPlot):
                 else:
                     raise ValueError('Either a SC or the z coordinate to slice the real space grid needs to be passed')
 
-                kwargs['sc'] = sisl.SuperCell([xmax-xmin, ymax-ymin, 1000], origin=origin)
+                kwargs['sc'] = sisl.Lattice([xmax-xmin, ymax-ymin, 1000], origin=origin)
 
             if 'axis' not in kwargs:
                 kwargs['axis'] = 2
@@ -183,7 +183,7 @@ class SpinPolarization(GeometryPlot):
         otherwise it only uses the geometry associated to the `hubbard.HubbardHamiltonian` (carbon backbone)
     realspace: bool, optional
         if True it plots the spin polarization in a realspace grid. In other case it will be plotted as Mulliken populations
-        If True either a `sisl.SuperCell` (`sc` kwarg) or the `z` kwarg to slice the real space grid at the desired z coordinate needs to be passed
+        If True either a `sisl.Lattice` (`sc` kwarg) or the `z` kwarg to slice the real space grid at the desired z coordinate needs to be passed
     """
 
     def __init__(self, HH, ext_geom=None, realspace=False, **kwargs):
@@ -224,7 +224,7 @@ class SpinPolarization(GeometryPlot):
                 else:
                     raise ValueError('Either a SC or the z coordinate to slice the real space grid needs to be passed')
 
-                kwargs['sc'] = sisl.SuperCell([xmax-xmin, ymax-ymin, 1000], origin=origin)
+                kwargs['sc'] = sisl.Lattice([xmax-xmin, ymax-ymin, 1000], origin=origin)
 
 
             if 'axis' not in kwargs:

--- a/hubbard/plot/spectrum.py
+++ b/hubbard/plot/spectrum.py
@@ -167,7 +167,7 @@ class LDOS_from_eigenstate(GeometryPlot):
     realspace:
         If True it will plot the LDOS in a realspace grid otherwise it plots it as a scatter plot (PDOS)
         with varying size depending on the PDOS numerical value
-        In this case either a `sisl.SuperCell` (`sc` kwarg) or the `z` kwarg to slice the real space grid at the desired z coordinate needs to be passed
+        In this case either a `sisl.Lattice` (`sc` kwarg) or the `z` kwarg to slice the real space grid at the desired z coordinate needs to be passed
     """
 
     def __init__(self, HH, wavefunction, sites=[], ext_geom=None, realspace=False, **kwargs):
@@ -206,7 +206,7 @@ class LDOS_from_eigenstate(GeometryPlot):
                 else:
                     raise ValueError('Either a SC or the z coordinate to slice the real space grid needs to be passed')
 
-                kwargs['sc'] = sisl.SuperCell([xmax-xmin, ymax-ymin, 1000], origin=origin)
+                kwargs['sc'] = sisl.Lattice([xmax-xmin, ymax-ymin, 1000], origin=origin)
 
 
             if 'axis' not in kwargs:
@@ -262,7 +262,7 @@ class LDOS(GeometryPlot):
     realspace:
         If True it will plot the LDOS in a realspace grid otherwise it plots it as a scatter plot (PDOS)
         with varying size depending on the PDOS numerical value
-        In this case either a `sisl.SuperCell` (`sc` kwarg) or the `z` kwarg to slice the real space grid at the desired z coordinate needs to be passed
+        In this case either a `sisl.Lattice` (`sc` kwarg) or the `z` kwarg to slice the real space grid at the desired z coordinate needs to be passed
 
     See Also
     ------------
@@ -303,7 +303,7 @@ class LDOS(GeometryPlot):
                 else:
                     raise ValueError('Either a SC or the z coordinate to slice the real space grid needs to be passed')
 
-                kwargs['sc'] = sisl.SuperCell([xmax-xmin, ymax-ymin, 1000], origin=origin)
+                kwargs['sc'] = sisl.Lattice([xmax-xmin, ymax-ymin, 1000], origin=origin)
 
             if 'axis' not in kwargs:
                 kwargs['axis'] = 2

--- a/hubbard/plot/wavefunction.py
+++ b/hubbard/plot/wavefunction.py
@@ -23,7 +23,7 @@ class Wavefunction(GeometryPlot):
     Notes
     -----
     If `realspace` kwarg is passed it plots the wavefunction in a realspace grid
-    In this case either a `sisl.SuperCell` (`sc` kwarg) or the `z` kwarg to slice the real space grid at the desired z coordinate needs to be passed
+    In this case either a `sisl.Lattice` (`sc` kwarg) or the `z` kwarg to slice the real space grid at the desired z coordinate needs to be passed
     In other case the wavefunction is plotted as a scatter plot, where the size of the blobs depend on the value
     of the coefficient of `wf` on the atomic sites
     """
@@ -60,7 +60,7 @@ class Wavefunction(GeometryPlot):
                 else:
                     raise ValueError('Either a SC or the z coordinate to slice the real space grid needs to be passed')
 
-                kwargs['sc'] = sisl.SuperCell([xmax-xmin, ymax-ymin, 1000], origin=origin)
+                kwargs['sc'] = sisl.Lattice([xmax-xmin, ymax-ymin, 1000], origin=origin)
 
             if 'axis' not in kwargs:
                 kwargs['axis'] = 2


### PR DESCRIPTION
Fix for sisl deprecation warning
```python
dep:0: SislDeprecation: SuperCell is deprecated; 
please use 'Lattice' class instead [>=0.15] [removed in 0.17]
```